### PR TITLE
Fix gh action

### DIFF
--- a/.github/workflows/ui-test.yml
+++ b/.github/workflows/ui-test.yml
@@ -4,8 +4,8 @@
 name: UI Tests
 
 on:
-  push:
   workflow_dispatch: # Allows manual triggering of the workflow
+  push:
     paths:
       - 'ui/**'
 


### PR DESCRIPTION
Fix the gh action for ui tests; the nesting appears to be incorrect and it causes ui actions to be ran on commits that aren't related to the ui see for example the tests ran in #35 