### PR TITLE
Add ASU branding to pygeoapi HTML

### DIFF
--- a/pygeoapi.config.yml
+++ b/pygeoapi.config.yml
@@ -10,6 +10,8 @@ server:
   cors: true
   pretty_print: true
   # admin: true
+  icon: https://www.asu.edu/themes/custom/asu_edu/favicon.ico
+  logo: https://awo-ui.netlify.app/ASU-logo.png
   templates:
     path: /opt/pygeoapi/pygeoapi-deployment/templates
   limits:


### PR DESCRIPTION
Not sure if there is a better static URL for the ASU logo. Currently just pulling it from the netlify deployment

<img width="638" height="419" alt="image" src="https://github.com/user-attachments/assets/745f2c80-1067-4e0b-9460-27035e66690a" />
