### PR TITLE
Add job to push to ghcr

### DIFF
--- a/.github/workflows/push_to_ghcr.yml
+++ b/.github/workflows/push_to_ghcr.yml
@@ -6,7 +6,6 @@ name: Push To GHCR
 on:
   push:
     branches: [main]
-  pull_request:
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
Github container registry supports buildkit and is generally easier to use and manage in CI compared to cloudbuild. 

As such I am adding this job. For the time being it is just a mirror; in the future we may be able to switch from the google container registry image to this one, however we are not in a rush for that; will wait to align before switching anything off cloudbuild