### PR TITLE
Push to ghcr instead of dockerhub

### DIFF
--- a/.github/workflows/push_to_ghcr.yml
+++ b/.github/workflows/push_to_ghcr.yml
@@ -39,4 +39,5 @@ jobs:
           push: true
           tags: ghcr.io/cgs-earth/asu-awo-pygeoapi:latest
           cache-from: type=gha,scope=asu-awo-pygeoapi
+          platforms: linux/amd64 linux/arm64
           cache-to: type=gha,mode=max,scope=asu-awo-pygeoapi


### PR DESCRIPTION
push to ghcr; I didn't realize that the gh action will try to auto push to dockerhub instead of ghcr even if you log in to ghcr