### PR TITLE
Add documentation and data source links for all datasets

### DIFF
--- a/pygeoapi.config.yml
+++ b/pygeoapi.config.yml
@@ -76,15 +76,15 @@ resources:
     links:
       - type: application/html
         rel: methodology
-        title: methodology
+        title: Methodology
         href: https://hdsc.nws.noaa.gov/pub/hdsc/data/papers/articles/HRL_Pubs_PDF_May12_2009/HRL_PUBS_201-250/206_CHANNEL_ROUTING,_HYDROLOGICAL_FORECASTING.pdf
       - type: application/html
         rel: canonical 
-        title: data source
+        title: Data source
         href: https://noaa-nwm-retrospective-3-0-pds.s3.amazonaws.com/index.html#CONUS/zarr/chrtout.zarr/
       - type: application/html
         rel: documentation
-        title: documentation
+        title: Documentation
         href: https://registry.opendata.aws/nwm-archive/
     extents:  &nwm-extents
       spatial:
@@ -124,11 +124,11 @@ resources:
     links:
       - type: application/html
         rel: canonical 
-        title: data source
+        title: Data source
         href: https://noaa-nwm-retrospective-3-0-pds.s3.amazonaws.com/index.html#CONUS/zarr/ldasout.zarr/
       - type: application/html
         rel: documentation
-        title: documentation
+        title: Documentation
         href: https://registry.opendata.aws/nwm-archive/
     providers:
       - &nwm-raster-edr
@@ -149,11 +149,11 @@ resources:
     links:
       - type: application/html
         rel: canonical 
-        title: data source
+        title: Data source
         href: https://noaa-nwm-retrospective-3-0-pds.s3.amazonaws.com/index.html#CONUS/zarr/rtout.zarr/
       - type: application/html
         rel: documentation
-        title: documentation
+        title: Documentation
         href: https://registry.opendata.aws/nwm-archive/
     providers:
       - <<: *nwm-raster-edr
@@ -168,11 +168,11 @@ resources:
     links:
       - type: application/html
         rel: canonical 
-        title: data source
+        title: Data source
         href: https://noaa-nwm-retrospective-3-0-pds.s3.amazonaws.com/index.html#CONUS/zarr/lakeout.zarr/
       - type: application/html
         rel: documentation
-        title: documentation
+        title: Documentation
         href: https://registry.opendata.aws/nwm-archive/
     providers:  
       - <<: *nwm-edr
@@ -225,11 +225,11 @@ resources:
     link:
       - type: application/html
         rel: canonical 
-        title: data source
+        title: Data source
         href: https://cwms-data.usace.army.mil/cwms-data/swagger-ui.html
       - type: application/html
         rel: documentation
-        title: documentation
+        title: Documentation
         href: https://water.usace.army.mil/
     extents: 
       spatial:
@@ -264,12 +264,12 @@ resources:
     links:
       - type: application/html
         rel: documentation
-        title: documentation
+        title: Documentation
         href: https://www.nrcs.usda.gov/wps/portal/wcc/home/aboutUs/monitoringPrograms/automatedSnowMonitoring/
         hreflang: en-US
       - type: application/html
         rel: canonical
-        title: data source
+        title: Data source
         href: https://wcc.sc.egov.usda.gov/awdbRestApi/swagger-ui/index.html
         hreflang: en-US
     extents:
@@ -297,12 +297,12 @@ resources:
     links:
       - type: application/html
         rel: documentation
-        title: documentation
+        title: Documentation
         href: https://labs.waterdata.usgs.gov/
         hreflang: en-US
       - type: application/html
         rel: canonical
-        title: data source
+        title: Data source
         href: https://labs.waterdata.usgs.gov/sta/v1.1/
     extents: &default-extent
       spatial:
@@ -332,12 +332,12 @@ resources:
     links:
       - type: application/html
         rel: documentation
-        title: documentation
+        title: Documentation
         href: https://www.nrcs.usda.gov/wps/portal/wcc/home/aboutUs/monitoringPrograms/automatedSnowMonitoring/
         hreflang: en-US
       - type: application/html
         rel: canonical
-        title: data source
+        title: Data source
         href: https://wcc.sc.egov.usda.gov/awdbRestApi/swagger-ui/index.html
         hreflang: en-US
     providers:
@@ -360,15 +360,23 @@ resources:
     links:
       - type: application/html
         rel: documentation
-        title: documentation
+        title: Documentation
         href: https://www.cbrfc.noaa.gov/wsup/graph/west/map/esp_map.html
         hreflang: en-US
-      #   # the datasource is the same as the documentation since this is an aggregation 
-      #   # of the data from the individual forecast centers
-      # - type: application/html
-      #   rel: canonical
-      #   title: data source
-      #   href: https://www.cbrfc.noaa.gov/wsup/graph/west/map/esp_map.html
+     # there are multiple canonical dataset sources here since noaa rfc joins data from multiple sources
+      - type: application/html
+        rel: canonical
+        title: California Nevada River Forecast Center Data Source
+        href: https://www.cnrfc.noaa.gov/ensembleProduct.php
+      - type: application/html
+        rel: canonical
+        title: Colorado Basin River Forecast Center Data Source
+        href: https://www.cbrfc.noaa.gov/lmap/lmap.php
+      - type: application/html
+        rel: canonical
+        title: Northwest River Forecast Center Data Source
+        href: https://www.nwrfc.noaa.gov/rfc/
+        
     extents: *default-extent
     providers:
       - type: feature
@@ -389,8 +397,12 @@ resources:
     links:
       - type: application/html
         rel: documentation
-        title: documentation
+        title: Documentation
         href: https://cida.usgs.gov/thredds/catalog.html?dataset=cida.usgs.gov/prism_v2
+      - type: application/html
+        rel: canonical
+        title: Data source
+        href: https://usgs.osn.mghpcc.org/mdmf/gdp/PRISM_v2.zarr
     providers:
       - type: edr
         name: xarray-edr
@@ -413,8 +425,14 @@ resources:
     keywords: [NOAA, riv_gauges]
     provider-name:
       - NOAA
-    links:
-      - <<: *default-link
+    links: &default-noaa-river-stage-links
+      - type: application/html
+        rel: documentation
+        title: Documentation
+        href: https://mapservices.weather.noaa.gov/eventdriven/rest/services/water/riv_gauges/MapServer
+      - type: application/html
+        rel: canonical
+        title: Data source
         href: https://mapservices.weather.noaa.gov/eventdriven/rest/services/water/riv_gauges/MapServer
     extents: *default-extent
     providers:
@@ -429,6 +447,7 @@ resources:
     <<: *default-river-stage
     title: NOAA River Stage Forecast Day 2
     description: predicts the water level (stage) in rivers and streams 2 days from now and is updated every 15-minutes
+    links: *default-noaa-river-stage-links
     providers:
       - <<: *default-feature-river-stage
         data: https://mapservices.weather.noaa.gov/eventdriven/rest/services/water/riv_gauges/MapServer/2
@@ -437,6 +456,7 @@ resources:
     <<: *default-river-stage
     title: NOAARiver Stage Forecast Day 3
     description: predicts the water level (stage) in rivers and streams 3 days from now and is updated every 15-minutes
+    links: *default-noaa-river-stage-links
     providers:
       - <<: *default-feature-river-stage
         data: https://mapservices.weather.noaa.gov/eventdriven/rest/services/water/riv_gauges/MapServer/3
@@ -445,29 +465,31 @@ resources:
     <<: *default-river-stage
     title: NOAA River Stage Forecast Day 10
     description: predicts the water level (stage) in rivers and streams 10 days from now and is updated every 15-minutes
+    links: *default-noaa-river-stage-links
     providers:
       - <<: *default-feature-river-stage
         data: https://mapservices.weather.noaa.gov/eventdriven/rest/services/water/riv_gauges/MapServer/10
 
 
-
-  arizona-well-registry:
-    type: collection
-    title: Arizona Wells 55 Registry
-    description: contains Arizona well information such as NOIs to drill, replace, modify, abandon, or deepen, registrations, driller reports, completion reports, change of well information, change of ownership, notice of well capping, and abandonment completion reports. 
-    keywords: [Arizona]
-    provider-name:
-      - Arizona Department of Water Resources
-    links:
-      - <<: *default-link
-        href: https://services.arcgis.com/C34zQ7veRS0V1t04/ArcGIS/rest/services/Well_Registry_2024/FeatureServer/0
-    extents: *default-extent
-    providers:
-      - type: feature
-        name: ESRI
-        data: https://services.arcgis.com/C34zQ7veRS0V1t04/ArcGIS/rest/services/Well_Registry_2024/FeatureServer/0
-        id_field: REGISTRY_ID
-        time_field: installed
+  ## This is commented out because it is superceded by the pgedr arizona ground water collection which contains both
+  ## the wells 55 data and the azwater.gov timeseries data in the same collection; this is only keppt here for posterity
+  # arizona-well-registry:
+  #   type: collection
+  #   title: Arizona Wells 55 Registry
+  #   description: contains Arizona well information such as NOIs to drill, replace, modify, abandon, or deepen, registrations, driller reports, completion reports, change of well information, change of ownership, notice of well capping, and abandonment completion reports. 
+  #   keywords: [Arizona]
+  #   provider-name:
+  #     - Arizona Department of Water Resources
+  #   links:
+  #     - <<: *default-link
+  #       href: https://services.arcgis.com/C34zQ7veRS0V1t04/ArcGIS/rest/services/Well_Registry_2024/FeatureServer/0
+  #   extents: *default-extent
+  #   providers:
+  #     - type: feature
+  #       name: ESRI
+  #       data: https://services.arcgis.com/C34zQ7veRS0V1t04/ArcGIS/rest/services/Well_Registry_2024/FeatureServer/0
+  #       id_field: REGISTRY_ID
+  #       time_field: installed
 
   usgs-national-map/elevation: 
     type: collection
@@ -477,9 +499,18 @@ resources:
       - USGS
     keywords: [USGS]
     links:
-      - <<: *default-link
-        href: https://tnmaccess.nationalmap.gov/api/v1/map_services
-        all_national_map_links: https://tnmaccess.nationalmap.gov/api/v1/map_services?outputFormat=pJSON
+      - type: application/html
+        rel: canonical
+        title: Data source
+        href: https://elevation.nationalmap.gov/arcgis/rest/services/3DEPElevation/ImageServer
+      - type: application/html
+        rel: documentation
+        title: Documentation
+        href: https://www.usgs.gov/3d-elevation-program
+      - type: application/html
+        rel: map list 
+        title: The list of all map services available by the USGS
+        href: https://tnmaccess.nationalmap.gov/api/v1/map_services?outputFormat=pJSON
     extents: *default-extent
     providers:
      -  type: map
@@ -501,9 +532,18 @@ resources:
       - USGS
     keywords: [USGS]
     links:
-      - <<: *default-link
-        href: https://tnmaccess.nationalmap.gov/api/v1/map_services
-        all_national_map_links: https://tnmaccess.nationalmap.gov/api/v1/map_services?outputFormat=pJSON
+      - type: application/html
+        rel: canonical
+        title: Data source
+        href: https://www.mrlc.gov/geoserver/NLCD_Land_Cover/wms
+      - type: application/html
+        rel: documentation
+        title: Documentation
+        href: https://www.usgs.gov/centers/eros/science/national-land-cover-database
+      - type: application/html
+        rel: map list 
+        title: List of all map services available by the USGS
+        href: https://tnmaccess.nationalmap.gov/api/v1/map_services?outputFormat=pJSON
     extents: *default-extent
     providers:
       - type: map
@@ -523,6 +563,24 @@ resources:
     description: consists of field-verified data regarding wells and springs collected by personnel from the Hydrology Division's Basic Data Section, the U.S. Geological Survey and other co-operating agencies. This collection contains additional info joined from the Arizona Wells 55 Registry to enrich well metadata.
     provider-name:
       - Arizona Department of Water Resources
+    links:
+      - type: application/html
+        rel: canonical
+        title: Wells 55 Registry Data Source
+        href: https://services.arcgis.com/C34zQ7veRS0V1t04/ArcGIS/rest/services/Well_Registry_2024/FeatureServer/0
+      - type: application/html
+        rel: canonical
+        title: Groundwater Timeseries Data source
+        href: https://www.azwater.gov/sites/default/files/zip/GWSI_ZIP_20251014.zip
+      - type: application/html
+        rel: documentation
+        title: ADWR Interactive Maps and Data Documentation
+        href: https://www.azwater.gov/gis-data-and-maps
+      - type: application/html
+        rel: documentation 
+        title: Water Resources Open Data Portal
+        href: https://gisdata2016-11-18t150447874z-azwater.opendata.arcgis.com/
+
     keywords:
       en:
         - example


### PR DESCRIPTION
- Remove arizona datasets that are superceded by the new pgedr arizona aggregated dataset that includes both wells55 and the groundwater site index 
- Add links with rel `canonical` or `documentation`: these can be parsed and displayed in the ui
    - Note that some collections have multiple canonical sources if they are an aggregate of multiple datasets / APIs such as the NOAA river forecast center which aggregates multiple regional river forecast centers