### PR TITLE
Bring in upstream pygeoapi/pgedr updates

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,8 +51,8 @@ server = [
 members = ["packages/*"]
 
 [tool.uv.sources]
-pygeoapi = { git = "https://github.com/internetofwater/pygeoapi.git", rev="f231e9bd057675dad4df5bbe0500cc2708ce3106" }
-pgedr = {git = "https://github.com/internetofwater/pgedr.git", rev="main"}
+pygeoapi = { git = "https://github.com/internetofwater/pygeoapi.git", rev="dbcb34802b72c4e4d61a5e60e6c13c9abd32c57b" }
+pgedr = {git = "https://github.com/internetofwater/pgedr.git", rev="eb6c86dc410bdfdd214c8cb8aa4a67943ae2968a"}
 # it appears that to get the latest code you need to specify the HEAD branch of each package
 usace = { git = "https://github.com/internetofwater/Western-Water-Datahub.git", subdirectory = "packages/usace", branch="main" }
 com = { git = "https://github.com/internetofwater/Western-Water-Datahub.git", subdirectory = "packages/com", branch="main" }

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = "==3.12.*"
 
 [manifest]
@@ -208,7 +208,7 @@ requires-dist = [
     { name = "opentelemetry-exporter-otlp", specifier = ">=1.35.0" },
     { name = "opentelemetry-instrumentation-aiohttp-client", specifier = ">=0.56b0" },
     { name = "orjson", specifier = ">=3.11.0" },
-    { name = "pgedr", git = "https://github.com/internetofwater/pgedr.git?rev=main" },
+    { name = "pgedr", git = "https://github.com/internetofwater/pgedr.git?rev=eb6c86dc410bdfdd214c8cb8aa4a67943ae2968a" },
     { name = "redis", specifier = ">=6.2.0" },
     { name = "rioxarray", specifier = ">=0.19.0" },
     { name = "rise", git = "https://github.com/internetofwater/Western-Water-Datahub.git?subdirectory=packages%2Frise&branch=main" },
@@ -228,7 +228,7 @@ dev = [
 ]
 server = [
     { name = "gunicorn", specifier = ">=23.0.0" },
-    { name = "pygeoapi", git = "https://github.com/internetofwater/pygeoapi.git?rev=f231e9bd057675dad4df5bbe0500cc2708ce3106" },
+    { name = "pygeoapi", git = "https://github.com/internetofwater/pygeoapi.git?rev=dbcb34802b72c4e4d61a5e60e6c13c9abd32c57b" },
     { name = "starlette", specifier = ">=0.47.0" },
     { name = "uvicorn", specifier = ">=0.34.3" },
 ]
@@ -1598,7 +1598,7 @@ wheels = [
 [[package]]
 name = "pgedr"
 version = "0.2.dev0"
-source = { git = "https://github.com/internetofwater/pgedr.git?rev=main#c77a2384b9db2482d0b8ffefb09296a9609cf298" }
+source = { git = "https://github.com/internetofwater/pgedr.git?rev=eb6c86dc410bdfdd214c8cb8aa4a67943ae2968a#eb6c86dc410bdfdd214c8cb8aa4a67943ae2968a" }
 dependencies = [
     { name = "cryptography" },
     { name = "geoalchemy2" },
@@ -1742,7 +1742,7 @@ wheels = [
 [[package]]
 name = "pygeoapi"
 version = "0.22.dev0"
-source = { git = "https://github.com/internetofwater/pygeoapi.git?rev=f231e9bd057675dad4df5bbe0500cc2708ce3106#f231e9bd057675dad4df5bbe0500cc2708ce3106" }
+source = { git = "https://github.com/internetofwater/pygeoapi.git?rev=dbcb34802b72c4e4d61a5e60e6c13c9abd32c57b#dbcb34802b72c4e4d61a5e60e6c13c9abd32c57b" }
 dependencies = [
     { name = "babel" },
     { name = "click" },


### PR DESCRIPTION
- Change PGEDR to be able to query single tables. Note, Locations with no data may appear in `/items` but will not appear in `/locations` or `/locations/{id}`
- Use correct parameter name for STA based EDR. Have some work i would like to bring into upstream pygeoapi but this should patch the parameter mis-match