### PR TITLE
Fix nan value in covjson response for NWM

### DIFF
--- a/packages/NationalWaterModel/src/NationalWaterModel/lib.py
+++ b/packages/NationalWaterModel/src/NationalWaterModel/lib.py
@@ -385,6 +385,8 @@ def dataset_to_covjson(
                             # time step. Since it is a list of lists we need to
                             # flatten
                             timeseries_arr[i]
+                            if not np.isnan(timeseries_arr[i])
+                            else None
                             for timeseries_arr in timeseries_values
                         ],
                     }


### PR DESCRIPTION
Closes #102 

http://localhost:5005/collections/National_Water_Model_Channel_Routing_Output/cube?bbox=-111.57318164296625%2C32.468501639793274%2C-109.52807005265342%2C34.134228236694&parameter-name=streamflow&datetime=2023-01-30%2F2023-01-31&f=json

works for me now
<img width="1356" height="879" alt="image" src="https://github.com/user-attachments/assets/40d6cc2f-44fe-4742-810d-16164fdb51a7" />
