### PR TITLE
Fix: share, PRISM restrictions, param select, opacity

### DIFF
--- a/ui/src/consts/collections.ts
+++ b/ui/src/consts/collections.ts
@@ -20,6 +20,7 @@ export enum CollectionId {
   AWDB = 'awdb-forecasts-edr',
 
   NOAARFC = 'noaa-rfc',
+  PRISM = 'usgs-prism',
 }
 
 export enum Provider {
@@ -166,6 +167,13 @@ export const CollectionRestrictions: Record<string, Restiction[]> = {
       type: RestrictionType.Parameter,
       count: 1,
       message: 'Select only one parameter.',
+    },
+  ],
+  [CollectionId.PRISM]: [
+    {
+      type: RestrictionType.Day,
+      days: 1095,
+      message: 'Select a date range no greater than three years.',
     },
   ],
 };

--- a/ui/src/features/Panel/Datasets/Dataset/Content.tsx
+++ b/ui/src/features/Panel/Datasets/Dataset/Content.tsx
@@ -10,6 +10,7 @@ import styles from '@/features/Panel/Panel.module.css';
 import { useLoading } from '@/hooks/useLoading';
 import { ICollection } from '@/services/edr.service';
 import { Layer } from '@/stores/main/types';
+import { CollectionType, getCollectionType } from '@/utils/collection';
 import { getParameterUnit } from '@/utils/parameters';
 
 type Props = {
@@ -34,6 +35,7 @@ export const Content: React.FC<Props> = (props) => {
   const [datasetLink, setDatasetLink] = useState('');
   const [sourceLink, setSourceLink] = useState('');
   const [documentationLink, setDocumentationLink] = useState('');
+  const [collectionType, setCollectionType] = useState<CollectionType>(CollectionType.Unknown);
 
   const { isFetchingCollections } = useLoading();
 
@@ -52,6 +54,9 @@ export const Content: React.FC<Props> = (props) => {
     setDatasetLink(datasetLink);
     setSourceLink(sourceLink);
     setDocumentationLink(documentationLink);
+
+    const collectionType = getCollectionType(dataset);
+    setCollectionType(collectionType);
 
     const paramObjects = Object.values(dataset?.parameter_names ?? {});
 
@@ -89,23 +94,28 @@ export const Content: React.FC<Props> = (props) => {
   return (
     <Stack gap="var(--default-spacing)" className={styles.accordionContent}>
       <Text size="sm">This dataset {dataset.description}</Text>
-      <Select
-        size="sm"
-        label="Default Parameters"
-        description="Show locations that contain data for selected parameter(s). Please note if more than one parameter is selected, shown locations may not contain data for all selected parameters."
-        placeholder="Select a Parameter"
-        multiple
-        clearable
-        searchable
-        data={data}
-        value={parameters}
-        onChange={handleParametersChange}
-        error={getParameterError()}
-      />
-      <Text size="xs" c="dimmed">
-        These will be the default parameters for all layers created from this dataset. Parameters
-        can be further customized for each layer instance within that layer's controls.
-      </Text>
+      {[CollectionType.EDR, CollectionType.EDRGrid].includes(collectionType) && (
+        <>
+          <Select
+            size="sm"
+            label="Default Parameters"
+            description="Show locations that contain data for selected parameter(s). Please note if more than one parameter is selected, shown locations may not contain data for all selected parameters."
+            placeholder="Select a Parameter"
+            multiple
+            clearable
+            searchable
+            data={data}
+            value={parameters}
+            onChange={handleParametersChange}
+            error={getParameterError()}
+          />
+          <Text size="xs" c="dimmed">
+            These will be the default parameters for all layers created from this dataset.
+            Parameters can be further customized for each layer instance within that layer's
+            controls.
+          </Text>
+        </>
+      )}
 
       <Group align="center" mt="var(--default-spacing)" gap="calc(var(--default-spacing) / 2)">
         {links.map(({ label, href, title }, index) => (

--- a/ui/src/features/Panel/Layers/Layer/index.tsx
+++ b/ui/src/features/Panel/Layers/Layer/index.tsx
@@ -223,11 +223,13 @@ const Layer: React.FC<Props> = (props) => {
   const isValidRange = from && to ? dayjs(from).isSameOrBefore(dayjs(to)) : true;
 
   /**
-   * This dataset supports date ranges
+   * This dataset supports time series for parameters
    *
    * @constant
    */
-  const showDateInputs = [CollectionType.EDR, CollectionType.EDRGrid].includes(collectionType);
+  const hasScientificMeasurements = [CollectionType.EDR, CollectionType.EDRGrid].includes(
+    collectionType
+  );
   /**
    * This is a features dataset, show additional message
    *
@@ -246,6 +248,12 @@ const Layer: React.FC<Props> = (props) => {
    * @constant
    */
   const showOpacitySlider = [CollectionType.Map, CollectionType.EDRGrid].includes(collectionType);
+  /**
+   * A raster layer can't be colorized
+   *
+   * @constant
+   */
+  const showColorInput = collectionType !== CollectionType.Map;
 
   const isPaletteDefinitionValid = isValidPalette(paletteDefinition);
 
@@ -263,6 +271,7 @@ const Layer: React.FC<Props> = (props) => {
     !isSameArray(parameters, layer.parameters) ||
     from !== layer.from ||
     to !== layer.to ||
+    opacity !== layer.opacity ||
     !isSamePalette(paletteDefinition, layer.paletteDefinition);
 
   /**
@@ -361,21 +370,23 @@ const Layer: React.FC<Props> = (props) => {
       <Group justify="space-between" gap="calc(var(--default-spacing) * 2)">
         <TextInput
           size="xs"
-          w={showPalette ? '100%' : 'calc(49% - (var(--default-spacing) * 2))'}
+          w={showPalette || !showColorInput ? '100%' : 'calc(49% - (var(--default-spacing) * 2))'}
           label="Layer Name"
           mr="auto"
           value={name}
           onChange={(event) => setName(event.currentTarget.value)}
         />
-        <Color
-          parameters={parameters}
-          parameterOptions={data}
-          color={color}
-          handleColorChange={handleColorChange}
-          paletteDefinition={paletteDefinition}
-          handlePaletteDefinitionChange={handlePaletteDefinitionChange}
-          collectionType={collectionType}
-        />
+        {showColorInput && (
+          <Color
+            parameters={parameters}
+            parameterOptions={data}
+            color={color}
+            handleColorChange={handleColorChange}
+            paletteDefinition={paletteDefinition}
+            handlePaletteDefinitionChange={handlePaletteDefinitionChange}
+            collectionType={collectionType}
+          />
+        )}
       </Group>
       {layer.paletteDefinition &&
         isValidPalette(layer.paletteDefinition) &&
@@ -393,7 +404,7 @@ const Layer: React.FC<Props> = (props) => {
           feature collection with accessible properties and no underlying data.
         </Text>
       )}
-      {showDateInputs && (
+      {hasScientificMeasurements && (
         <>
           <Divider />
           <Group justify="space-between">


### PR DESCRIPTION
This PR applies fixes for several minor issues.

1. Share functionality would encounter issues with layer ordering and basemap selections
   - Should now be resolved and have improved logic + feedback
2. PRISM needed a date range restriction, would crash app ~15 years
   - Now set to max of 3 years
3. Default parameters select was rendered for features and map datasets
   - Should no longer be shown in both datasets content and layer content
4. Raster layers showed a color input
   - Should no longer be shown
5. Opacity slider only applied to fill and raster opacity 
   - Opacity slider is only available for coverage grids & raster
   - Opacity slider now applies primarily to lines
   - Fill opacity will always be set at 70% of line opacity