### PR TITLE
Allow restoring groundwater db locally

### DIFF
--- a/db/jobs.sql
+++ b/db/jobs.sql
@@ -1,0 +1,72 @@
+-- Copyright 2026 Lincoln Institute of Land Policy
+-- SPDX-License-Identifier: Apache-2.0
+
+--
+-- PostgreSQL database dump from https://github.com/geopython/pygeoapi/blob/master/tests/data/postgres_manager_full_structure.backup.sql
+--
+
+-- Dumped from database version 14.12 (Ubuntu 14.12-1.pgdg20.04+1)
+-- Dumped by pg_dump version 16.3 (Ubuntu 16.3-1.pgdg20.04+1)
+
+SET statement_timeout = 0;
+SET lock_timeout = 0;
+SET idle_in_transaction_session_timeout = 0;
+SET client_encoding = 'UTF8';
+SET standard_conforming_strings = on;
+SELECT pg_catalog.set_config('search_path', '', false);
+SET check_function_bodies = false;
+SET xmloption = content;
+SET client_min_messages = warning;
+SET row_security = off;
+
+--
+-- Name: public; Type: SCHEMA; Schema: -; Owner: postgres
+--
+
+ALTER SCHEMA public OWNER TO postgres;
+
+SET default_tablespace = '';
+
+SET default_table_access_method = heap;
+
+--
+-- Name: jobs; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.jobs (
+    type character varying DEFAULT 'process'::character varying NOT NULL,
+    identifier character varying NOT NULL,
+    process_id character varying NOT NULL,
+    created timestamp without time zone,
+    started timestamp without time zone,
+    finished timestamp without time zone,
+    updated timestamp without time zone,
+    status character varying NOT NULL,
+    location character varying,
+    mimetype character varying,
+    message character varying,
+    progress integer NOT NULL
+);
+
+
+ALTER TABLE public.jobs OWNER TO postgres;
+
+--
+-- Name: jobs jobs_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.jobs
+    ADD CONSTRAINT jobs_pkey PRIMARY KEY (identifier);
+
+
+--
+-- Name: SCHEMA public; Type: ACL; Schema: -; Owner: postgres
+--
+
+REVOKE USAGE ON SCHEMA public FROM PUBLIC;
+GRANT ALL ON SCHEMA public TO PUBLIC;
+
+
+--
+-- PostgreSQL database dump complete
+--

--- a/db/restore.sh
+++ b/db/restore.sh
@@ -1,0 +1,42 @@
+#!/bin/sh
+# Copyright 2026 Lincoln Institute of Land Policy
+# SPDX-License-Identifier: Apache-2.0
+
+set -e
+
+# This script will restore the database from the backup
+# and create the jobs table that is necessary for the postgres
+# job manager in pygeoapi
+# this is mainly just for local testing
+
+# set the cwd to this script's directory
+cd "$(dirname "$0")"
+
+# prompt if you want to download the backup; if yes then download; else no 
+
+read -p "Do you want to download a new backup? (y/n) " -n 1 -r
+echo    
+if [[ $REPLY =~ ^[Yy]$ ]]
+then
+  echo "Downloading backup"
+  oras pull ghcr.io/cgs-earth/arizona-groundwater-dump:latest
+fi
+
+export PGPASSWORD="changeMe"
+
+
+psql -h localhost -U postgres -c "DROP DATABASE IF EXISTS edr;"
+psql -h localhost -U postgres -c "CREATE DATABASE edr;"
+
+echo "Restoring database"
+pg_restore \
+  -h localhost \
+  -U postgres \
+  -d edr \
+  -j 8 \
+  edr_backup.dump
+
+echo "Database restored. Creating jobs table"
+psql -h localhost -U postgres -d edr -f jobs.sql
+echo "Done"
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,29 @@ services:
     profiles:
       - production
 
+  database:
+    image: postgis/postgis:17-3.6-alpine
+    platform: linux/amd64
+
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: changeMe
+      POSTGRES_DB: edr
+
+    ports:
+      - "5432:5432"
+
+    volumes:
+      - awo_postgres_data:/var/lib/postgresql/data
+
+    healthcheck:
+      test: >
+        CMD-SHELL
+        pg_isready -U "$POSTGRES_USER" -d "$POSTGRES_DB"
+      interval: 10s
+      timeout: 8s
+      retries: 5
+
   redis:
     image: redislabs/redismod
     ports:
@@ -55,4 +78,5 @@ services:
       - ui
 
 volumes:
-  redis_data:
+  redis_data: 
+  awo_postgres_data:

--- a/makefile
+++ b/makefile
@@ -35,6 +35,15 @@ clean:
 build:
 	docker compose build pygeoapi
 
+# To pull the latest groundwater data and restore it into the db
+# you can run the following
+restore_db_dump_locally:
+	./db/restore.sh
+
+# If you wish to query the production db you can use the following
+proxy_db:
+	cloud-sql-proxy asu-awo:us-south1:postgis --port=5432
+
 # For adwr we ocassionally update the data. since it is not a crawl
 # and is a manual download we also have to do a manual update with a command
 # like this and put it in the yml


### PR DESCRIPTION
Previously when running the backend locally I was proxying the db.

This PR allows a user to restore the db locally so that one can use it for local dev without needing gcloud credentials or using a proxy.

This is useful for the handoff