### PR TITLE
Fix links typo for USACE

### DIFF
--- a/pygeoapi.config.yml
+++ b/pygeoapi.config.yml
@@ -246,7 +246,7 @@ resources:
     description: provides a subset of the USACE Corps Water Management System (CWMS) API specifically focused on water control management data
     provider-name:  
       - US Army Corps of Engineers
-    link:
+    links:
       - type: application/html
         rel: canonical 
         title: Data source


### PR DESCRIPTION
`links` mistakenly had a typo named `link`