### PR TITLE
Add fix for NWM soil parameter

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,3 +4,10 @@
 **/zarr/
 **/*.zarr/
 **/*.nc
+*.dump
+node_modules/
+zarr*/
+*.parquet
+*.7z
+zarr_dataset/
+*.gdb

--- a/makefile
+++ b/makefile
@@ -32,9 +32,6 @@ clean:
 	rm -rf .logs_queue
 	rm -rf .venv/
 
-build:
-	docker compose build pygeoapi
-
 # To pull the latest groundwater data and restore it into the db
 # you can run the following
 restore_db_dump_locally:

--- a/packages/NationalWaterModel/src/NationalWaterModel/lib.py
+++ b/packages/NationalWaterModel/src/NationalWaterModel/lib.py
@@ -156,6 +156,12 @@ def project_dataset(
         return dataset.assign_coords({x_field: x_proj, y_field: y_proj})
 
     else:
+        # There are special cases of certain datasets in the national water model
+        # where there are multiple soil layers. We need to select the first one
+        # otherwise the reproject will fail due to excessive number of dimensions
+        if "soil_layers_stag" in dataset.dims:
+            dataset = dataset.isel(soil_layers_stag=0)
+
         # if the dataset is raster we need to reproject it. raster datasets
         # a non linear crs are non trivial to reproject so it is easiest to just
         # use rio.reproject


### PR DESCRIPTION
Currently this query fails: https://asu-awo-pygeoapi-864861257574.us-south1.run.app/collections/National_Water_Model_Land_Data_Assimilation_System_Output/cube?bbox=-108,37,-107,38&parameter-name=SOIL_W&datetime=2021-01-01&f=html

since the parameter for `SOIL_W` includes an extra dimension. There are multiple soil layers and as such, because of a dimension mismatch you can't do a crs projection.

---

This PR fixes that. It is currently a relatively naive fix since it is a special case specifically for the National_Water_Model_Land_Data_Assimilation_System_Output dataset for Sara to get the AWO use case development done

http://localhost:5005/collections/National_Water_Model_Land_Data_Assimilation_System_Output/cube?bbox=-108,37,-107,38&parameter-name=SOIL_W&datetime=2021-01-01&f=html

<img width="1725" height="856" alt="image" src="https://github.com/user-attachments/assets/dfbba2f3-36a1-4e9d-980e-f79f503a8078" />
