### PR TITLE
Change Management Area typo

### DIFF
--- a/pygeoapi.config.yml
+++ b/pygeoapi.config.yml
@@ -696,9 +696,9 @@ resources:
         data: https://services3.arcgis.com/0OPQIK59PJJqLK0A/arcgis/rest/services/Aquifers_USGS_West/FeatureServer/0
         id_field: OBJECTID
 
-  Active_Managment_Areas_2025:
+  Active_Management_Areas_2025:
     type: collection
-    title: Kyl Center for Water Policy Arizona Water Active Managment Areas
+    title: Kyl Center for Water Policy Arizona Water Active Management Areas
     description: contains designated groundwater-management zones where water withdrawals are under regulatory oversight to address overdraft and ensure long-term sustainability
     provider-name:
       - Kyl Center for Water Policy
@@ -707,7 +707,7 @@ resources:
     links:
       - type: application/html
         rel: canonical
-        title: Active Managment Areas
+        title: Active Management Areas
         href: https://services3.arcgis.com/0OPQIK59PJJqLK0A/ArcGIS/rest/services/Active_Managment_Areas_2025/FeatureServer/0
       - type: application/html
         rel: documentation


### PR DESCRIPTION
There is a typo in the name of the management areas layer. This is since I brought the same exact name from the ESRI layer which has the source of the typo.

NOTE: We will need to tell everyone to update the code in the user guide and jupyter notebook for the demo before we merge this, just so nothing is broken due to this change.