### PR TITLE
Add pygeoapi deployment location env variable

### DIFF
--- a/makefile
+++ b/makefile
@@ -9,7 +9,7 @@ check:
 
 dev:
 	test -f local.openapi.yml || uv run pygeoapi openapi generate pygeoapi.config.yml --output-file local.openapi.yml
-	PYGEOAPI_CONFIG=pygeoapi.config.yml PYGEOAPI_OPENAPI=local.openapi.yml uv run pygeoapi serve
+	PYGEOAPI_CONFIG=pygeoapi.config.yml PYGEOAPI_OPENAPI=local.openapi.yml PYGEOAPI_DEPLOYMENT_DIR=$(pwd)/pygeoapi-deployment uv run pygeoapi serve
 
 deps:
 	# Using uv, install all Python dependencies needed for local development and spin up necessary docker services

--- a/pygeoapi.config.yml
+++ b/pygeoapi.config.yml
@@ -11,8 +11,8 @@ server:
   pretty_print: true
   # admin: true
   templates:
-    static: /opt/pygeoapi/pygeoapi-deployment/static
-    path: /opt/pygeoapi/pygeoapi-deployment/templates
+    static: ${PYGEOAPI_DEPLOYMENT_DIR:-/opt/pygeoapi/pygeoapi-deployment}/static
+    path: ${PYGEOAPI_DEPLOYMENT_DIR:-/opt/pygeoapi/pygeoapi-deployment}/templates
   limits:
     default_items: 500
     max_items: 10000


### PR DESCRIPTION
Add environment variable `PYGEOAPI_DEPLOYMENT_DIR` to allow proper routing of static assents when running in development. Would prefer avoiding setting a variable at all but the static assets are located in a different location when containerized.