### PR TITLE
Feature: Add functionality for persisting notifications and showing in history

### DIFF
--- a/ui/src/assets/Notifications.tsx
+++ b/ui/src/assets/Notifications.tsx
@@ -1,0 +1,14 @@
+/**
+ * Copyright 2025 Lincoln Institute of Land Policy
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+const Minus: React.FC = () => {
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 -960 960 960">
+      <path d="M160-200v-80h80v-280q0-83 50-147.5T420-792v-28q0-25 17.5-42.5T480-880q25 0 42.5 17.5T540-820v28q80 20 130 84.5T720-560v280h80v80H160Zm320-300Zm0 420q-33 0-56.5-23.5T400-160h160q0 33-23.5 56.5T480-80ZM320-280h320v-280q0-66-47-113t-113-47q-66 0-113 47t-47 113v280Z" />
+    </svg>
+  );
+};
+
+export default Minus;

--- a/ui/src/features/Charts/index.tsx
+++ b/ui/src/features/Charts/index.tsx
@@ -22,7 +22,7 @@ import loadingManager from '@/managers/Loading.init';
 import notificationManager from '@/managers/Notification.init';
 import { CoverageCollection, CoverageJSON, ICollection } from '@/services/edr.service';
 import { Location } from '@/stores/main/types';
-import { LoadingType, NotificationType } from '@/stores/session/types';
+import { LoadingType, NotificationVariant } from '@/stores/session/types';
 import { getDatetime } from '@/utils/url';
 
 dayjs.extend(isSameOrBefore);
@@ -180,7 +180,7 @@ export const Charts: React.FC<Props> = ({
       if (rejected.length > 0) {
         notificationManager.show(
           `Some locations failed to load (${rejected.length}/${pending.length}).`,
-          NotificationType.Info,
+          NotificationVariant.Info,
           8000
         );
       }

--- a/ui/src/features/Notifications/History.tsx
+++ b/ui/src/features/Notifications/History.tsx
@@ -1,0 +1,66 @@
+/**
+ * Copyright 2026 Lincoln Institute of Land Policy
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Box, Notification, Stack, Tooltip } from '@mantine/core';
+import NotificationsIcon from '@/assets/Notifications';
+import IconButton from '@/components/IconButton';
+import { Variant } from '@/components/types';
+import styles from '@/features/Notifications/Notifications.module.css';
+import notificationManager from '@/managers/Notification.init';
+import { Notification as NotificationType, NotificationVariant } from '@/stores/session/types';
+
+type Props = {
+  show: boolean;
+  onClick: (show: boolean) => void;
+  notifications: NotificationType[];
+  getColor: (type: NotificationVariant) => 'red' | 'green' | undefined;
+};
+
+export const History: React.FC<Props> = (props) => {
+  const { show, onClick, notifications, getColor } = props;
+
+  const count = notifications.filter(
+    (notificiation) => !notificiation.visible && !notificiation.viewed
+  ).length;
+
+  return (
+    <>
+      {show && (
+        <Stack
+          gap="calc(var(--default-spacing) / 2)"
+          align="flex-end"
+          className={styles.notificationStack}
+        >
+          {notifications.map((notification) => (
+            <Notification
+              key={notification.id}
+              className={styles.notification}
+              color={getColor(notification.type)}
+              onClose={() => notificationManager.delete(notification.id)}
+              onMouseEnter={() => notificationManager.viewed(notification.id)}
+            >
+              {notification.message}
+            </Notification>
+          ))}
+        </Stack>
+      )}
+      <Tooltip label="Change map styling." disabled={show}>
+        <Box mt="calc(var(--default-spacing) / 2)">
+          <IconButton
+            variant={show ? Variant.Selected : Variant.Secondary}
+            onClick={() => onClick(!show)}
+          >
+            <NotificationsIcon />
+          </IconButton>
+          {count > 0 && (
+            <Box component="span" className={styles.unviewedCountIcon}>
+              {count}
+            </Box>
+          )}
+        </Box>
+      </Tooltip>
+    </>
+  );
+};

--- a/ui/src/features/Notifications/History.tsx
+++ b/ui/src/features/Notifications/History.tsx
@@ -46,7 +46,7 @@ export const History: React.FC<Props> = (props) => {
           ))}
         </Stack>
       )}
-      <Tooltip label="Change map styling." disabled={show}>
+      <Tooltip label="View notifications." disabled={show}>
         <Box mt="calc(var(--default-spacing) / 2)">
           <IconButton
             variant={show ? Variant.Selected : Variant.Secondary}

--- a/ui/src/features/Notifications/Notifications.module.css
+++ b/ui/src/features/Notifications/Notifications.module.css
@@ -5,7 +5,28 @@
 
 .notificationsWrapper {
   position: absolute;
-  bottom: 30px;
-  right: 50px;
+  bottom: 1.875rem;
+  right: 3.125rem;
   z-index: 9999;
+}
+
+.unviewedCountIcon {
+  position: absolute;
+  bottom: 1.5rem;
+  right: -0.1875rem;
+  background: var(--mantine-color-default);
+  padding: 0 0.375rem;
+  font-size: 12px;
+  border-radius: 100%;
+}
+
+.notification {
+  min-height: 2.8125rem;
+  height: 2.8125rem;
+}
+
+.notificationStack {
+  max-height: calc(100vh - 8.75rem);
+  overflow-y: auto;
+  padding-right: calc(var(--default-spacing) / 2);
 }

--- a/ui/src/features/Notifications/index.tsx
+++ b/ui/src/features/Notifications/index.tsx
@@ -5,11 +5,11 @@
 
 import { Box, Notification, Stack } from '@mantine/core';
 import { useDisclosure } from '@mantine/hooks';
+import { History } from '@/features/Notifications/History';
 import styles from '@/features/Notifications/Notifications.module.css';
 import notificationManager from '@/managers/Notification.init';
 import useSessionStore from '@/stores/session';
 import { NotificationVariant } from '@/stores/session/types';
-import { History } from './History';
 
 const Notifications: React.FC = () => {
   const notifications = useSessionStore((state) => state.notifications);

--- a/ui/src/features/Notifications/index.tsx
+++ b/ui/src/features/Notifications/index.tsx
@@ -4,40 +4,73 @@
  */
 
 import { Box, Notification, Stack } from '@mantine/core';
+import { useDisclosure } from '@mantine/hooks';
 import styles from '@/features/Notifications/Notifications.module.css';
 import notificationManager from '@/managers/Notification.init';
 import useSessionStore from '@/stores/session';
-import { NotificationType } from '@/stores/session/types';
+import { NotificationVariant } from '@/stores/session/types';
+import { History } from './History';
 
 const Notifications: React.FC = () => {
   const notifications = useSessionStore((state) => state.notifications);
 
-  const getColor = (type: NotificationType) => {
+  const [opened, { open, close }] = useDisclosure(false);
+
+  const getColor = (type: NotificationVariant) => {
     switch (type) {
-      case NotificationType.Error:
+      case NotificationVariant.Error:
         return 'red';
-      case NotificationType.Success:
+      case NotificationVariant.Success:
         return 'green';
-      case NotificationType.Info:
+      case NotificationVariant.Info:
       default:
         return undefined;
     }
   };
 
+  const handleClick = (show: boolean) => {
+    if (show) {
+      open();
+    } else {
+      close();
+    }
+  };
+
+  if (notifications.length === 0) {
+    return;
+  }
+
   return (
     <Box className={styles.notificationsWrapper}>
-      <Stack>
-        {notifications.map((notification) => (
-          <Notification
-            key={notification.id}
-            color={getColor(notification.type)}
-            onClose={() => notificationManager.hide(notification.id)}
-            onMouseEnter={() => notificationManager.pause(notification.id)}
-            onMouseLeave={() => notificationManager.resume(notification.id)}
+      <Stack gap="var(--default-spacing)" align="flex-end">
+        {!opened && (
+          <Stack
+            gap="calc(var(--default-spacing) / 2)"
+            align="flex-end"
+            className={styles.notificationStack}
           >
-            {notification.message}
-          </Notification>
-        ))}
+            {notifications
+              .filter((notification) => notification.visible)
+              .map((notification) => (
+                <Notification
+                  key={notification.id}
+                  className={styles.notification}
+                  color={getColor(notification.type)}
+                  onClose={() => notificationManager.hide(notification.id)}
+                  onMouseEnter={() => notificationManager.pause(notification.id)}
+                  onMouseLeave={() => notificationManager.resume(notification.id)}
+                >
+                  {notification.message}
+                </Notification>
+              ))}
+          </Stack>
+        )}
+        <History
+          show={opened}
+          onClick={handleClick}
+          notifications={notifications}
+          getColor={getColor}
+        />
       </Stack>
     </Box>
   );

--- a/ui/src/features/Panel/Datasets/Dataset/Control.tsx
+++ b/ui/src/features/Panel/Datasets/Dataset/Control.tsx
@@ -16,7 +16,7 @@ import warningManager from '@/managers/Warning.init';
 import { ICollection } from '@/services/edr.service';
 import useMainStore from '@/stores/main';
 import { Layer } from '@/stores/main/types';
-import { LoadingType, NotificationType } from '@/stores/session/types';
+import { LoadingType, NotificationVariant } from '@/stores/session/types';
 import { CollectionType, getCollectionType } from '@/utils/collection';
 
 type Props = {
@@ -83,13 +83,13 @@ export const Control: React.FC<Props> = (props) => {
       }
 
       await mainManager.createLayer(id, parameters, controller.current.signal);
-      notificationManager.show(`Added layer for: ${name}`, NotificationType.Success);
+      notificationManager.show(`Added layer for: ${name}`, NotificationVariant.Success);
     } catch (error) {
       if ((error as Error)?.message) {
         const _error = error as Error;
-        notificationManager.show(`Error: ${_error.message}`, NotificationType.Error, 10000);
+        notificationManager.show(`Error: ${_error.message}`, NotificationVariant.Error, 10000);
       } else if (typeof error === 'string') {
-        notificationManager.show(`Error: ${error}`, NotificationType.Error, 10000);
+        notificationManager.show(`Error: ${error}`, NotificationVariant.Error, 10000);
       }
     } finally {
       loadingManager.remove(loadingInstance);

--- a/ui/src/features/Panel/Datasets/Filter/Modal/Category.tsx
+++ b/ui/src/features/Panel/Datasets/Filter/Modal/Category.tsx
@@ -21,7 +21,7 @@ import loadingManager from '@/managers/Loading.init';
 import notificationManager from '@/managers/Notification.init';
 import awoService from '@/services/init/awo.init';
 import { MainState } from '@/stores/main/types';
-import { LoadingType, NotificationType } from '@/stores/session/types';
+import { LoadingType, NotificationVariant } from '@/stores/session/types';
 
 type Props = {
   category: MainState['category'];
@@ -94,7 +94,7 @@ export const Category: React.FC<Props> = (props) => {
           setCategoryOptions([]);
           setNoOptions(true);
         } else {
-          notificationManager.show(`Error: ${_error.message}`, NotificationType.Error, 10000);
+          notificationManager.show(`Error: ${_error.message}`, NotificationVariant.Error, 10000);
         }
       }
     } finally {

--- a/ui/src/features/Panel/Layers/Layer/index.tsx
+++ b/ui/src/features/Panel/Layers/Layer/index.tsx
@@ -18,7 +18,7 @@ import loadingManager from '@/managers/Loading.init';
 import mainManager from '@/managers/Main.init';
 import notificationManager from '@/managers/Notification.init';
 import { Layer as LayerType } from '@/stores/main/types';
-import { LoadingType, NotificationType } from '@/stores/session/types';
+import { LoadingType, NotificationVariant } from '@/stores/session/types';
 import { CollectionType, getCollectionType } from '@/utils/collection';
 import { getRandomHexColor } from '@/utils/hexColor';
 import { getParameterUnit } from '@/utils/parameters';
@@ -225,11 +225,11 @@ const Layer: React.FC<Props> = (props) => {
         opacity,
         paletteDefinition
       );
-      notificationManager.show(`Updated layer: ${updateName}`, NotificationType.Success);
+      notificationManager.show(`Updated layer: ${updateName}`, NotificationVariant.Success);
     } catch (error) {
       if ((error as Error)?.message) {
         const _error = error as Error;
-        notificationManager.show(`Error: ${_error.message}`, NotificationType.Error, 10000);
+        notificationManager.show(`Error: ${_error.message}`, NotificationVariant.Error, 10000);
       }
     } finally {
       loadingManager.remove(loadingInstance);
@@ -249,7 +249,7 @@ const Layer: React.FC<Props> = (props) => {
 
   const handleDelete = () => {
     mainManager.deleteLayer(layer);
-    notificationManager.show(`Deleted layer: ${layer.name}`, NotificationType.Success);
+    notificationManager.show(`Deleted layer: ${layer.name}`, NotificationVariant.Success);
   };
 
   const handleNameChange = useCallback((name: LayerType['name']) => setName(name), [setName]);

--- a/ui/src/features/Panel/index.tsx
+++ b/ui/src/features/Panel/index.tsx
@@ -33,7 +33,7 @@ import loadingManager from '@/managers/Loading.init';
 import mainManager from '@/managers/Main.init';
 import notificationManager from '@/managers/Notification.init';
 import useMainStore from '@/stores/main';
-import { LoadingType, NotificationType } from '@/stores/session/types';
+import { LoadingType, NotificationVariant } from '@/stores/session/types';
 
 const Panel: React.FC = () => {
   const mobile = useMediaQuery('(max-width: 899px)');
@@ -47,11 +47,11 @@ const Panel: React.FC = () => {
     const loadingInstance = loadingManager.add('Fetching all datasets.', LoadingType.Collections);
     try {
       await mainManager.getCollections();
-      notificationManager.show('Updated datasets', NotificationType.Success);
+      notificationManager.show('Updated datasets', NotificationVariant.Success);
     } catch (error) {
       if ((error as Error)?.message) {
         const _error = error as Error;
-        notificationManager.show(`Error: ${_error.message}`, NotificationType.Error, 10000);
+        notificationManager.show(`Error: ${_error.message}`, NotificationVariant.Error, 10000);
       }
     } finally {
       loadingManager.remove(loadingInstance);

--- a/ui/src/features/Tools/DateSelector/Entry.tsx
+++ b/ui/src/features/Tools/DateSelector/Entry.tsx
@@ -17,7 +17,7 @@ import loadingManager from '@/managers/Loading.init';
 import mainManager from '@/managers/Main.init';
 import notificationManager from '@/managers/Notification.init';
 import { Layer } from '@/stores/main/types';
-import { LoadingType, NotificationType } from '@/stores/session/types';
+import { LoadingType, NotificationVariant } from '@/stores/session/types';
 
 dayjs.extend(utc);
 dayjs.extend(timezone);
@@ -57,9 +57,9 @@ export const Entry: React.FC<Props> = (props) => {
     } catch (err) {
       const error = err as Error;
       if ((error?.message ?? '').length > 0 && error?.name !== 'AbortError') {
-        notificationManager.show((err as Error)?.message, NotificationType.Error, 10000);
+        notificationManager.show((err as Error)?.message, NotificationVariant.Error, 10000);
       } else if (typeof err === 'string') {
-        notificationManager.show(err, NotificationType.Error, 10000);
+        notificationManager.show(err, NotificationVariant.Error, 10000);
       }
     } finally {
       loadingManager.remove(loadingInstance);
@@ -95,9 +95,9 @@ export const Entry: React.FC<Props> = (props) => {
     } catch (err) {
       const error = err as Error;
       if ((error?.message ?? '').length > 0 && error?.name !== 'AbortError') {
-        notificationManager.show((err as Error)?.message, NotificationType.Error, 10000);
+        notificationManager.show((err as Error)?.message, NotificationVariant.Error, 10000);
       } else if (typeof err === 'string') {
-        notificationManager.show(err, NotificationType.Error, 10000);
+        notificationManager.show(err, NotificationVariant.Error, 10000);
       }
     } finally {
       loadingManager.remove(loadingInstance);

--- a/ui/src/features/Tools/Draw.tsx
+++ b/ui/src/features/Tools/Draw.tsx
@@ -24,7 +24,7 @@ import useMainStore from '@/stores/main';
 import { DrawMode } from '@/stores/main/types';
 import useSessionStore from '@/stores/session';
 import { MeasureUnit } from '@/stores/session/slices/measure';
-import { LoadingType, NotificationType, Overlay } from '@/stores/session/types';
+import { LoadingType, NotificationVariant, Overlay } from '@/stores/session/types';
 
 export const Draw: React.FC = () => {
   const [show, setShow] = useState(false);
@@ -59,9 +59,9 @@ export const Draw: React.FC = () => {
     } catch (error) {
       if ((error as Error)?.message) {
         const _error = error as Error;
-        notificationManager.show(`Error: ${_error.message}`, NotificationType.Error, 10000);
+        notificationManager.show(`Error: ${_error.message}`, NotificationVariant.Error, 10000);
       } else if (typeof error === 'string') {
-        notificationManager.show(`Error: ${error}`, NotificationType.Error, 10000);
+        notificationManager.show(`Error: ${error}`, NotificationVariant.Error, 10000);
       }
     } finally {
       loadingInstance.current = loadingManager.remove(loadingInstance.current);
@@ -105,7 +105,7 @@ export const Draw: React.FC = () => {
       draw.changeMode('draw_polygon');
       notificationManager.show(
         'Finish drawing the shape, or click the cancel button to exit the draw tool.',
-        NotificationType.Info,
+        NotificationVariant.Info,
         10000
       );
     }
@@ -122,7 +122,7 @@ export const Draw: React.FC = () => {
       setDrawMode(DrawMode.Measure);
       notificationManager.show(
         'Click two points on the map to measure the distance between.',
-        NotificationType.Info,
+        NotificationVariant.Info,
         10000
       );
       if (map) {

--- a/ui/src/features/Tools/Screenshot.tsx
+++ b/ui/src/features/Tools/Screenshot.tsx
@@ -22,7 +22,7 @@ import styles from '@/features/Tools/Tools.module.css';
 import notificationManager from '@/managers/Notification.init';
 import useMainStore from '@/stores/main';
 import useSessionStore from '@/stores/session';
-import { NotificationType, Overlay } from '@/stores/session/types';
+import { NotificationVariant, Overlay } from '@/stores/session/types';
 import { handleCreateMapImage } from '@/utils/screenshot';
 
 export const Screenshot: React.FC = () => {
@@ -203,7 +203,7 @@ export const Screenshot: React.FC = () => {
       });
       downloadDataUrl(dataUrl, `${name}-legend.jpg`);
     } catch (err) {
-      notificationManager.show((err as Error).message, NotificationType.Error, 10000);
+      notificationManager.show((err as Error).message, NotificationVariant.Error, 10000);
     }
   };
 

--- a/ui/src/features/TopBar/Links/Grid.tsx
+++ b/ui/src/features/TopBar/Links/Grid.tsx
@@ -33,7 +33,7 @@ import {
 } from '@/services/edr.service';
 import awoService from '@/services/init/awo.init';
 import { Layer, Location as LocationType } from '@/stores/main/types';
-import { LoadingType, NotificationType } from '@/stores/session/types';
+import { LoadingType, NotificationVariant } from '@/stores/session/types';
 import { createEmptyCsv } from '@/utils/csv';
 import { getIdStore } from '@/utils/getIdStore';
 import { normalizeBBox } from '@/utils/normalizeBBox';
@@ -161,7 +161,7 @@ export const Grid = forwardRef<HTMLDivElement, Props>((props, ref) => {
       if (res.status === 204) {
         notificationManager.show(
           `No data found for location: ${location.id} with the current parameter and date range selection.`,
-          NotificationType.Error,
+          NotificationVariant.Error,
           10000
         );
         objectUrl = createEmptyCsv();
@@ -178,12 +178,12 @@ export const Grid = forwardRef<HTMLDivElement, Props>((props, ref) => {
 
       URL.revokeObjectURL(objectUrl);
       a.remove();
-      notificationManager.show('CSV generated successfully.', NotificationType.Success, 10000);
+      notificationManager.show('CSV generated successfully.', NotificationVariant.Success, 10000);
     } catch (err) {
       if (((err as Error)?.message ?? '').length > 0) {
-        notificationManager.show((err as Error)?.message, NotificationType.Error, 10000);
+        notificationManager.show((err as Error)?.message, NotificationVariant.Error, 10000);
       } else if (typeof err === 'string') {
-        notificationManager.show(err, NotificationType.Error, 10000);
+        notificationManager.show(err, NotificationVariant.Error, 10000);
       }
     } finally {
       loadingManager.remove(loadingInstance);

--- a/ui/src/features/TopBar/Links/GridsChart.tsx
+++ b/ui/src/features/TopBar/Links/GridsChart.tsx
@@ -25,7 +25,7 @@ import {
 } from '@/services/edr.service';
 import awoService from '@/services/init/awo.init';
 import { Layer } from '@/stores/main/types';
-import { NotificationType } from '@/stores/session/types';
+import { NotificationVariant } from '@/stores/session/types';
 import { getIdStore } from '@/utils/getIdStore';
 import { getLabel } from '@/utils/getLabel';
 import { normalizeBBox } from '@/utils/normalizeBBox';
@@ -177,7 +177,7 @@ export const GridsChart: React.FC<Props> = (props) => {
       onEntryError: (name, error) => {
         notificationManager.show(
           `An error occurred generating file: ${name}. See console for further details.`,
-          NotificationType.Error,
+          NotificationVariant.Error,
           10000
         );
         console.error('Error', name, error);
@@ -186,7 +186,7 @@ export const GridsChart: React.FC<Props> = (props) => {
     });
 
     if (isMounted.current) {
-      notificationManager.show("All CSV's generated", NotificationType.Success, 10000);
+      notificationManager.show("All CSV's generated", NotificationVariant.Success, 10000);
 
       const objectUrl = URL.createObjectURL(zipBlob);
       const a = document.createElement('a');

--- a/ui/src/features/TopBar/Links/LayerBlock.tsx
+++ b/ui/src/features/TopBar/Links/LayerBlock.tsx
@@ -20,7 +20,7 @@ import notificationManager from '@/managers/Notification.init';
 import { ICollection } from '@/services/edr.service';
 import { Layer, Location as LocationType } from '@/stores/main/types';
 import useSessionStore from '@/stores/session';
-import { NotificationType } from '@/stores/session/types';
+import { NotificationVariant } from '@/stores/session/types';
 import { chunk } from '@/utils/chunk';
 import { CollectionType } from '@/utils/collection';
 import { buildCubeUrl, buildItemsUrl, buildLocationsUrl } from '@/utils/url';
@@ -83,7 +83,7 @@ export const LayerBlock: React.FC<Props> = (props) => {
       // TODO: determine cause of duplicates
       const message = `Unable to create base URL for layer: ${collection.title}. Skipping this entry in the Export modal.`;
       if (!hasNotification(message)) {
-        notificationManager.show(message, NotificationType.Error, 10000);
+        notificationManager.show(message, NotificationVariant.Error, 10000);
       }
     }
   }, [collection, collectionType]);

--- a/ui/src/features/TopBar/Links/Location.tsx
+++ b/ui/src/features/TopBar/Links/Location.tsx
@@ -31,7 +31,7 @@ import {
 } from '@/services/edr.service';
 import awoService from '@/services/init/awo.init';
 import { Layer, Location as LocationType } from '@/stores/main/types';
-import { LoadingType, NotificationType } from '@/stores/session/types';
+import { LoadingType, NotificationVariant } from '@/stores/session/types';
 import { createEmptyCsv } from '@/utils/csv';
 import { getIdStore } from '@/utils/getIdStore';
 import { getLabel } from '@/utils/getLabel';
@@ -168,7 +168,7 @@ export const Location = forwardRef<HTMLDivElement, Props>((props, ref) => {
       if (res.status === 204) {
         notificationManager.show(
           `No data found for location: ${location.id} with the current parameter and date range selection.`,
-          NotificationType.Error,
+          NotificationVariant.Error,
           10000
         );
         objectUrl = createEmptyCsv();
@@ -185,12 +185,12 @@ export const Location = forwardRef<HTMLDivElement, Props>((props, ref) => {
 
       URL.revokeObjectURL(objectUrl);
       a.remove();
-      notificationManager.show('CSV generated successfully.', NotificationType.Success, 10000);
+      notificationManager.show('CSV generated successfully.', NotificationVariant.Success, 10000);
     } catch (err) {
       if (((err as Error)?.message ?? '').length > 0) {
-        notificationManager.show((err as Error)?.message, NotificationType.Error, 10000);
+        notificationManager.show((err as Error)?.message, NotificationVariant.Error, 10000);
       } else if (typeof err === 'string') {
-        notificationManager.show(err, NotificationType.Error, 10000);
+        notificationManager.show(err, NotificationVariant.Error, 10000);
       }
     } finally {
       loadingManager.remove(loadingInstance);

--- a/ui/src/features/TopBar/Links/LocationsChart.tsx
+++ b/ui/src/features/TopBar/Links/LocationsChart.tsx
@@ -26,7 +26,7 @@ import {
 } from '@/services/edr.service';
 import awoService from '@/services/init/awo.init';
 import { Layer, Location } from '@/stores/main/types';
-import { NotificationType } from '@/stores/session/types';
+import { NotificationVariant } from '@/stores/session/types';
 import { getIdStore } from '@/utils/getIdStore';
 import { getLabel } from '@/utils/getLabel';
 import { getParameterUnit } from '@/utils/parameters';
@@ -148,7 +148,7 @@ export const LocationsChart: React.FC<Props> = (props) => {
       onEntryError: (name, error) => {
         notificationManager.show(
           `An error occurred generating file: ${name}. See console for further details.`,
-          NotificationType.Error,
+          NotificationVariant.Error,
           10000
         );
         console.error('Error', name, error);
@@ -157,7 +157,7 @@ export const LocationsChart: React.FC<Props> = (props) => {
     });
 
     if (isMounted.current) {
-      notificationManager.show("All CSV's generated", NotificationType.Success, 10000);
+      notificationManager.show("All CSV's generated", NotificationVariant.Success, 10000);
 
       const objectUrl = URL.createObjectURL(zipBlob);
       const a = document.createElement('a');

--- a/ui/src/managers/Main.manager.ts
+++ b/ui/src/managers/Main.manager.ts
@@ -67,7 +67,7 @@ import {
   ParameterGroupMembers,
   TGeometryTypes,
 } from '@/stores/main/types';
-import { NotificationType } from '@/stores/session/types';
+import { NotificationVariant } from '@/stores/session/types';
 import { CollectionType, getCollectionType, isEdrGrid } from '@/utils/collection';
 import { createDynamicStepExpression, isSamePalette } from '@/utils/colors';
 import { ColorBrewerIndex, isValidColorBrewerIndex } from '@/utils/colors/types';
@@ -825,7 +825,7 @@ class MainManager {
         if (isValidColorBrewerIndex(newCount) && newCount !== actualCount) {
           notificationManager.show(
             `Duplicate thresholds detected. Reducing to ${newCount} threshold(s)`,
-            NotificationType.Info,
+            NotificationVariant.Info,
             5000
           );
         }
@@ -1328,7 +1328,7 @@ class MainManager {
     if (aggregate.features.length === 0) {
       const message = this.getNoDataMessage(layer.name, parameters.length, collectionId);
 
-      notificationManager.show(message, NotificationType.Info, 10000);
+      notificationManager.show(message, NotificationVariant.Info, 10000);
     }
 
     (aggregate as any) = undefined;
@@ -1722,7 +1722,7 @@ class MainManager {
         if (result.status === 'rejected') {
           notificationManager.show(
             'An error occurred while applying a spatial filter, check the console for more details.',
-            NotificationType.Error,
+            NotificationVariant.Error,
             10000
           );
           console.error('applySpatialFilter: addData failed:', result.reason);
@@ -1837,7 +1837,7 @@ class MainManager {
             if (paletteDefinition.actualCount !== newCount) {
               notificationManager.show(
                 `Duplicate thresholds detected. Reducing to ${newCount} threshold(s)`,
-                NotificationType.Info,
+                NotificationVariant.Info,
                 5000
               );
             }

--- a/ui/src/managers/Notification.manager.ts
+++ b/ui/src/managers/Notification.manager.ts
@@ -5,7 +5,7 @@
 
 import { v6 } from 'uuid';
 import { StoreApi, UseBoundStore } from 'zustand';
-import { Notification, NotificationType, SessionState } from '@/stores/session/types';
+import { Notification, NotificationVariant, SessionState } from '@/stores/session/types';
 
 type Timer = {
   timeoutId: ReturnType<typeof setTimeout>;
@@ -40,14 +40,14 @@ class NotificationManager {
 
   private startTimer(id: Notification['id'], duration: number): ReturnType<typeof setTimeout> {
     return setTimeout(() => {
-      this.store.getState().removeNotification(id);
+      this.store.getState().hideNotification(id);
       this.remove(id);
     }, duration);
   }
 
   show(
     message: string,
-    type: NotificationType = NotificationType.Info,
+    type: NotificationVariant = NotificationVariant.Info,
     duration: number = 3000
   ): Notification['id'] {
     const id = this.createUUID();
@@ -57,6 +57,8 @@ class NotificationManager {
       message,
       type,
       visible: true,
+      viewed: false,
+      createdAt: Date.now(),
     });
 
     const startTime = Date.now();
@@ -104,6 +106,21 @@ class NotificationManager {
       throw new Error(`Error: no timer instance found for id: ${id}`);
     }
 
+    if (timer) {
+      clearTimeout(timer.timeoutId);
+      this.remove(id);
+    }
+    this.store.getState().hideNotification(id);
+  }
+
+  viewed(id: string) {
+    this.store.getState().markViewed(id);
+  }
+
+  delete(id: string) {
+    const timer = this.get(id);
+
+    // This notification will likely not have a timeout instance
     if (timer) {
       clearTimeout(timer.timeoutId);
       this.remove(id);

--- a/ui/src/managers/Notification.manager.ts
+++ b/ui/src/managers/Notification.manager.ts
@@ -84,6 +84,8 @@ class NotificationManager {
       clearTimeout(timer.timeoutId);
       timer.remaining -= Date.now() - timer.startTime;
     }
+
+    this.store.getState().markViewed(id);
   }
 
   resume(id: string) {

--- a/ui/src/managers/__tests__/Notification.test.ts
+++ b/ui/src/managers/__tests__/Notification.test.ts
@@ -8,7 +8,7 @@ import '@testing-library/jest-dom';
 import { vi } from 'vitest';
 import { StoreApi, UseBoundStore } from 'zustand';
 import useSessionStore from '@/stores/session';
-import { NotificationType, SessionState } from '@/stores/session/types';
+import { NotificationVariant, SessionState } from '@/stores/session/types';
 import NotificationManager from '../Notification.manager';
 
 describe('NotificationManager', () => {
@@ -27,7 +27,7 @@ describe('NotificationManager', () => {
   });
 
   test('should show a notification and add it to the store', () => {
-    const id = notificationManager.show('Test message', NotificationType.Info, 1000);
+    const id = notificationManager.show('Test message', NotificationVariant.Info, 1000);
 
     const notifications = store.getState().notifications;
     expect(notifications.length).toBe(1);
@@ -37,7 +37,7 @@ describe('NotificationManager', () => {
   });
 
   test('should hide a notification and remove it from the store', () => {
-    const id = notificationManager.show('Hide me', NotificationType.Info, 1000);
+    const id = notificationManager.show('Hide me', NotificationVariant.Info, 1000);
 
     notificationManager.hide(id);
 
@@ -48,7 +48,7 @@ describe('NotificationManager', () => {
   test('should pause and resume a notification timer', () => {
     vi.useFakeTimers();
 
-    const id = notificationManager.show('Pause me', NotificationType.Info, 3000);
+    const id = notificationManager.show('Pause me', NotificationVariant.Info, 3000);
     vi.advanceTimersByTime(1000);
 
     notificationManager.pause(id);
@@ -70,7 +70,7 @@ describe('NotificationManager', () => {
   test('should auto-remove notification after duration', () => {
     vi.useFakeTimers();
 
-    notificationManager.show('Auto remove', NotificationType.Info, 1000);
+    notificationManager.show('Auto remove', NotificationVariant.Info, 1000);
 
     vi.advanceTimersByTime(1000);
 

--- a/ui/src/managers/__tests__/Notification.test.ts
+++ b/ui/src/managers/__tests__/Notification.test.ts
@@ -23,7 +23,7 @@ describe('NotificationManager', () => {
 
   afterEach(() => {
     const notifications = store.getState().notifications;
-    notifications.forEach((notification) => notificationManager.hide(notification.id));
+    notifications.forEach((notification) => notificationManager.delete(notification.id));
   });
 
   test('should show a notification and add it to the store', () => {
@@ -36,13 +36,15 @@ describe('NotificationManager', () => {
     expect(notification?.message).toBe('Test message');
   });
 
-  test('should hide a notification and remove it from the store', () => {
+  test('should hide a notification and remove it from visibility', () => {
     const id = notificationManager.show('Hide me', NotificationVariant.Info, 1000);
 
     notificationManager.hide(id);
 
-    const notifications = store.getState().notifications;
-    expect(notifications.length).toBe(0);
+    const notifications = store
+      .getState()
+      .notifications.filter((notification) => !notification.visible);
+    expect(notifications.length).toBe(1);
   });
 
   test('should pause and resume a notification timer', () => {
@@ -61,22 +63,57 @@ describe('NotificationManager', () => {
 
     vi.advanceTimersByTime(2000);
 
-    const notifications = store.getState().notifications;
-    expect(notifications.length).toBe(0);
+    const notifications = store
+      .getState()
+      .notifications.filter((notification) => !notification.visible);
+    expect(notifications.length).toBe(1);
 
     vi.useRealTimers();
   });
 
-  test('should auto-remove notification after duration', () => {
+  test('should auto-remove mark not visible after duration', () => {
     vi.useFakeTimers();
 
     notificationManager.show('Auto remove', NotificationVariant.Info, 1000);
 
     vi.advanceTimersByTime(1000);
 
-    const notifications = store.getState().notifications;
-    expect(notifications.length).toBe(0);
+    const notifications = store
+      .getState()
+      .notifications.filter((notification) => !notification.visible);
+    expect(notifications.length).toBe(1);
 
     vi.useRealTimers();
+  });
+
+  test('should delete a notification and remove it from the store', () => {
+    const id = notificationManager.show('Delete me', NotificationVariant.Info, 1000);
+
+    notificationManager.delete(id);
+
+    const notifications = store.getState().notifications;
+    expect(notifications.length).toBe(0);
+  });
+
+  test('should mark a notification viewed directly', () => {
+    const id = notificationManager.show('View me', NotificationVariant.Info, 1000);
+
+    notificationManager.viewed(id);
+
+    const notifications = store
+      .getState()
+      .notifications.filter((notification) => notification.viewed);
+    expect(notifications.length).toBe(1);
+  });
+
+  test('should mark a notification viewed when paused', () => {
+    const id = notificationManager.show('Pause and view me', NotificationVariant.Info, 1000);
+
+    notificationManager.pause(id);
+
+    const notifications = store
+      .getState()
+      .notifications.filter((notification) => notification.viewed);
+    expect(notifications.length).toBe(1);
   });
 });

--- a/ui/src/pages/Layout.page.tsx
+++ b/ui/src/pages/Layout.page.tsx
@@ -20,7 +20,7 @@ import mainManager from '@/managers/Main.init';
 import notificationManager from '@/managers/Notification.init';
 import styles from '@/pages/pages.module.css';
 import useMainStore from '@/stores/main';
-import { LoadingType, NotificationType } from '@/stores/session/types';
+import { LoadingType, NotificationVariant } from '@/stores/session/types';
 
 export const LayoutPage: React.FC = () => {
   const controller = useRef<AbortController>(null);
@@ -47,16 +47,16 @@ export const LayoutPage: React.FC = () => {
           if (loaded) {
             notificationManager.show(
               'Shared configuration loaded successfully.',
-              NotificationType.Success
+              NotificationVariant.Success
             );
             setShareId(shareId);
             setConfigGenerated(true);
           } else {
-            notificationManager.show('Unable to load config.', NotificationType.Error);
+            notificationManager.show('Unable to load config.', NotificationVariant.Error);
           }
         }
       } else if (typeof response === 'string') {
-        notificationManager.show(response, NotificationType.Error);
+        notificationManager.show(response, NotificationVariant.Error);
       }
     } catch (error) {
       if (
@@ -66,7 +66,7 @@ export const LayoutPage: React.FC = () => {
         console.log('Fetch request canceled');
       } else if ((error as Error)?.message) {
         const _error = error as Error;
-        notificationManager.show(`Error: ${_error.message}`, NotificationType.Error, 10000);
+        notificationManager.show(`Error: ${_error.message}`, NotificationVariant.Error, 10000);
       }
     } finally {
       loadingManager.remove(loadingInstance);

--- a/ui/src/services/coverageJSON/coverageChart.service.ts
+++ b/ui/src/services/coverageJSON/coverageChart.service.ts
@@ -9,7 +9,7 @@ import notificationManager from '@/managers/Notification.init';
 import { CoverageService } from '@/services/coverageJSON/coverage.service';
 import { TChartData, TCoverageOptions, TOptions, TValues } from '@/services/coverageJSON/types';
 import { CoverageAxesValues, CoverageCollection, CoverageJSON } from '@/services/edr.service';
-import { NotificationType } from '@/stores/session/types';
+import { NotificationVariant } from '@/stores/session/types';
 import { isAxesValues, isCoverageCollection } from '@/utils/isTypeObject';
 import { getParameterUnit } from '@/utils/parameters';
 
@@ -92,7 +92,7 @@ export class CoverageChartService extends CoverageService {
     if (this.isSegments(xObj) && this.isSegments(yObj)) {
       notificationManager.show(
         `Domain type ${coverage.domain.domainType}, sub-type segments is not currently supported.`,
-        NotificationType.Error,
+        NotificationVariant.Error,
         10000
       );
       return [];
@@ -109,7 +109,7 @@ export class CoverageChartService extends CoverageService {
     const coverageParameters = coverage.parameters ?? options?.parameters;
 
     if (!coverage.ranges) {
-      notificationManager.show('Missing ranges in coverage data', NotificationType.Error, 10000);
+      notificationManager.show('Missing ranges in coverage data', NotificationVariant.Error, 10000);
       return [];
     }
 
@@ -166,7 +166,7 @@ export class CoverageChartService extends CoverageService {
     if (!coverage.ranges || !dates) {
       notificationManager.show(
         'Missing ranges or date axis in coverage data',
-        NotificationType.Error,
+        NotificationVariant.Error,
         10000
       );
       return [];
@@ -243,7 +243,7 @@ export class CoverageChartService extends CoverageService {
 
     notificationManager.show(
       `Domain type ${coverage.domain.domainType} is not currently supported.`,
-      NotificationType.Error,
+      NotificationVariant.Error,
       10000
     );
     return [];

--- a/ui/src/stores/session/slices/notifications.ts
+++ b/ui/src/stores/session/slices/notifications.ts
@@ -10,6 +10,8 @@ export interface NotificationsSlice {
   notifications: Notification[];
   addNotification: (notification: Notification) => void;
   removeNotification: (id: string) => void;
+  hideNotification: (id: string) => void;
+  markViewed: (id: string) => void;
   hasNotification: (text: string) => boolean;
 }
 
@@ -22,8 +24,28 @@ export const createNotificationsSlice: StateCreator<
   notifications: [],
   addNotification: (notification) =>
     set((state) => ({
-      notifications: [...state.notifications, notification],
+      notifications: [...state.notifications, { ...notification, createdAt: Date.now() }],
     })),
+  hideNotification: (id) =>
+    set((state) => {
+      const notification = state.notifications.find((notification) => notification.id === id);
+
+      if (!notification || !notification.visible) {
+        return;
+      }
+
+      notification.visible = false;
+    }),
+  markViewed: (id) =>
+    set((state) => {
+      const notification = state.notifications.find((notification) => notification.id === id);
+
+      if (!notification || notification.viewed) {
+        return;
+      }
+
+      notification.viewed = true;
+    }),
   removeNotification: (id) =>
     set((state) => ({
       notifications: state.notifications.filter((notification) => notification.id !== id),

--- a/ui/src/stores/session/types.ts
+++ b/ui/src/stores/session/types.ts
@@ -10,7 +10,7 @@ import { MeasureSlice } from '@/stores/session/slices/measure';
 import { NotificationsSlice } from '@/stores/session/slices/notifications';
 import { WarningsSlice } from '@/stores/session/slices/warning';
 
-export enum NotificationType {
+export enum NotificationVariant {
   Success = 'success',
   Error = 'error',
   Info = 'info',
@@ -46,9 +46,11 @@ export enum Overlay {
 
 export type Notification = {
   id: string;
+  createdAt: number;
   message: string;
-  type: NotificationType;
-  visible: boolean;
+  type: NotificationVariant;
+  visible: boolean; // This notification is visible on screen
+  viewed: boolean; // This notification has been viewed in history
 };
 
 export type Warning = {


### PR DESCRIPTION
### **Description:**
Notifications now persist and can be viewed after they're removed from the screen. Use the notifications menu to view and remove old notifications.

### **To Test**
1. Perform actions in app that spawn notifications
    a. Add layers, delete layers, spawn AOI errors
2. After the lifecycle of the notification ends, the notification is still visible in the history
3. Notifications that have not been viewed in history or interacted with while still visible will be indicated by a count on the history button
4. Viewing a notification (hovering mouse over) will decrease the count by one
5. Notifications removed from history are permanently deleted