### PR TITLE
Feature: Add Support for Point Type

### DIFF
--- a/ui/src/services/coverageJSON/coverage.service.ts
+++ b/ui/src/services/coverageJSON/coverage.service.ts
@@ -21,7 +21,6 @@ export class CoverageService {
   }
 
   getValues(coverage: CoverageJSON, options?: TCoverageOptions): TValues {
-    console.log('GetValues');
     const filteredRanges = Object.entries(coverage.ranges).filter(([parameterId]) => {
       if (options?.chosenParameter) {
         const parameterEntry = coverage.parameters[parameterId];
@@ -43,13 +42,11 @@ export class CoverageService {
 
     const keys: TValues = {};
     let keyValues = filteredRanges.map((entry) => entry[0]);
-    console.log('keyvalue:', keyValues, 'coverage', coverage, 'filteredRanges', filteredRanges);
+
     if (coverage.parameters) {
       keyValues = Object.keys(coverage.parameters);
-      console.log('coverege parmaters', keyValues);
     }
     for (const key of keyValues) {
-      console.log(coverage.ranges[key]);
       if (coverage.ranges[key]?.values) {
         keys[key] = coverage.ranges[key].values;
       }

--- a/ui/src/services/coverageJSON/coverage.service.ts
+++ b/ui/src/services/coverageJSON/coverage.service.ts
@@ -21,6 +21,7 @@ export class CoverageService {
   }
 
   getValues(coverage: CoverageJSON, options?: TCoverageOptions): TValues {
+    console.log('GetValues');
     const filteredRanges = Object.entries(coverage.ranges).filter(([parameterId]) => {
       if (options?.chosenParameter) {
         const parameterEntry = coverage.parameters[parameterId];
@@ -41,12 +42,17 @@ export class CoverageService {
     });
 
     const keys: TValues = {};
-    let keyValues = Object.keys(filteredRanges);
+    let keyValues = filteredRanges.map((entry) => entry[0]);
+    console.log('keyvalue:', keyValues, 'coverage', coverage, 'filteredRanges', filteredRanges);
     if (coverage.parameters) {
       keyValues = Object.keys(coverage.parameters);
+      console.log('coverege parmaters', keyValues);
     }
     for (const key of keyValues) {
-      keys[key] = coverage.ranges[key].values;
+      console.log(coverage.ranges[key]);
+      if (coverage.ranges[key]?.values) {
+        keys[key] = coverage.ranges[key].values;
+      }
     }
     return keys;
   }

--- a/ui/src/services/coverageJSON/coverage.service.ts
+++ b/ui/src/services/coverageJSON/coverage.service.ts
@@ -42,7 +42,6 @@ export class CoverageService {
 
     const keys: TValues = {};
     let keyValues = filteredRanges.map((entry) => entry[0]);
-
     if (coverage.parameters) {
       keyValues = Object.keys(coverage.parameters);
     }

--- a/ui/src/services/coverageJSON/coverageChart.service.ts
+++ b/ui/src/services/coverageJSON/coverageChart.service.ts
@@ -290,7 +290,7 @@ export class CoverageChartService extends CoverageService {
     if (this.isSegments(xObj) && this.isSegments(yObj)) {
       notificationManager.show(
         `Domain type ${coverage.domain.domainType}, sub-type segments is not currently supported.`,
-        NotificationType.Error,
+        NotificationVariant.Error,
         10000
       );
       return [];

--- a/ui/src/services/coverageJSON/coverageChart.service.ts
+++ b/ui/src/services/coverageJSON/coverageChart.service.ts
@@ -213,6 +213,95 @@ export class CoverageChartService extends CoverageService {
 
     return series;
   }
+  private addPointValuesConstructor(
+    xValues: number[],
+    yValues: number[],
+    series: EChartsSeries[],
+    parameters: CoverageJSON['parameters'],
+    times: (string | number)[],
+    values: TValues
+  ) {
+    const count = times.length;
+
+    const xLength = xValues.length;
+    const yLength = yValues.length;
+
+    const getCurrentValues = this.getCurrentValuesConstructor(count, values, xLength, yLength);
+    let id = 1;
+
+    return (x: number, y: number) => {
+      const currentValues = getCurrentValues(x, y);
+      if (Object.values(currentValues).every((array) => array.every((value) => value === null))) {
+        return;
+      }
+
+      const [parameterId, data] = Object.entries(currentValues)[0];
+      if (Object.values(data).every((value) => value === null)) {
+        return;
+      }
+      // This grid entry would have no values to display
+      const parameter = parameters[parameterId];
+      const unit = getParameterUnit(parameter);
+      series.push({
+        name: `${parameterId} point ${id}`,
+        parameter: parameterId,
+        unit,
+        data: data as number[],
+        type: 'line',
+      });
+      id += 1;
+    };
+  }
+
+  private processPointValues(
+    timesObj: CoverageAxesValues,
+    xObj: CoverageAxesValues,
+    yObj: CoverageAxesValues,
+    coverage: CoverageJSON,
+    options?: TCoverageOptions
+  ): EChartsSeries[] {
+    let values: TValues | null = this.getValues(coverage, options);
+
+    const series: EChartsSeries[] = [];
+
+    const coverageParameters = coverage.parameters;
+
+    const addPoint = this.addPointValuesConstructor(
+      xObj.values as number[],
+      yObj.values as number[],
+      series,
+      coverageParameters,
+      timesObj.values,
+      values
+    );
+
+    for (let y = 0; y < yObj.values.length; y++) {
+      for (let x = 0; x < xObj.values.length; x++) {
+        addPoint(x, y);
+      }
+    }
+    values = null;
+
+    return series;
+  }
+  private processPoint(coverage: CoverageJSON, options?: TCoverageOptions) {
+    const { t, x: xObj, y: yObj } = this.getAxes(coverage);
+
+    if (this.isSegments(xObj) && this.isSegments(yObj)) {
+      notificationManager.show(
+        `Domain type ${coverage.domain.domainType}, sub-type segments is not currently supported.`,
+        NotificationType.Error,
+        10000
+      );
+      return [];
+    }
+
+    if (this.isValues(xObj) && this.isValues(yObj)) {
+      return this.processPointValues(t, xObj, yObj, coverage, options);
+    }
+
+    return [];
+  }
 
   private coverageCollectionToSeries(coverage: CoverageCollection, options?: TOptions) {
     const parameters = coverage.parameters as CoverageJSON['parameters'];
@@ -241,6 +330,9 @@ export class CoverageChartService extends CoverageService {
       return this.processGrid(coverage, options);
     }
 
+    if (coverage.domain.domainType === 'Point') {
+      return this.processPoint(coverage, options);
+    }
     notificationManager.show(
       `Domain type ${coverage.domain.domainType} is not currently supported.`,
       NotificationType.Error,

--- a/ui/src/services/coverageJSON/coverageChart.service.ts
+++ b/ui/src/services/coverageJSON/coverageChart.service.ts
@@ -231,6 +231,7 @@ export class CoverageChartService extends CoverageService {
 
     return (x: number, y: number) => {
       const currentValues = getCurrentValues(x, y);
+      // Check to determine if the paramater selected has a value.
       if (Object.values(currentValues).every((array) => array.every((value) => value === null))) {
         return;
       }
@@ -239,7 +240,7 @@ export class CoverageChartService extends CoverageService {
       if (Object.values(data).every((value) => value === null)) {
         return;
       }
-      // This grid entry would have no values to display
+
       const parameter = parameters[parameterId];
       const unit = getParameterUnit(parameter);
       series.push({


### PR DESCRIPTION
Description
This adds support for locations to have a point type collection

To Test
1.add a layer that has a point type collection
2.click on the location on the map
3.observe the chart displaying the data

Location example: [https://arizonawaterobservatory-api.rtd.asu.edu/collections/ArizonaWaterWells/locations/332241110461201?parameter-name=DEPTH_TO_WATER&datetime=2022-09-01/..&f=json&limit=1](https://arizonawaterobservatory-api.rtd.asu.edu/collections/ArizonaWaterWells/locations/332241110461201?parameter-name=DEPTH_TO_WATER&datetime=2022-09-01/..&f=json&limit=1)