### PR TITLE
Optimize SMAP ETL workflow

### DIFF
--- a/SMAP_ETL/src/lib.py
+++ b/SMAP_ETL/src/lib.py
@@ -17,6 +17,7 @@ import pandas as pd
 import pyproj
 from pyproj import Transformer
 import xarray as xr
+import zarr
 
 LOGGER = logging.getLogger(__name__)
 
@@ -211,6 +212,21 @@ def parse_time_from_path(hd5_file_path: Path):
     return datetime.datetime.strptime(timestamp_str, "%Y%m%dT%H%M%S")
 
 
+# SMAP variables to keep
+# Note this doesn't include dataset info like coordinates
+# or dataset metadata; this is just the list of timeseries vars
+TIMESERIES_VARIABLES_TO_KEEP = [
+    "sm_profile",
+    "sm_profile_pctl",
+    "sm_profile_wetness",
+    "sm_rootzone",
+    "sm_rootzone_pctl",
+    "sm_rootzone_wetness",
+    "sm_surface",
+    "sm_surface_wetness",
+]
+
+
 def append_hd5_to_s3_zarr(
     hd5_file_path: Path,
     s3_fs,
@@ -273,6 +289,11 @@ def append_hd5_to_s3_zarr(
     # Drop raw lat/lon — redundant now that we have x/y in meters
     ds = ds.drop_vars(["cell_lat", "cell_lon"], errors="ignore")
 
+    vars_to_drop = [
+        v for v in ds.data_vars if v not in TIMESERIES_VARIABLES_TO_KEEP
+    ]
+    ds = ds.drop_vars(vars_to_drop, errors="ignore")
+
     # Extract time from filename; we will use this as the time dimension
     # and serialize it with pandas so it can be used in queries
     time_value = pd.Timestamp(parse_time_from_path(hd5_file_path))
@@ -284,7 +305,11 @@ def append_hd5_to_s3_zarr(
     # Create fsspec mapper for Zarr store
     zarr_mapper = s3_fs.get_mapper(f"{bucket}/{store_name}")
 
-    store_exists = bool(list(zarr_mapper.keys()))
+    try:
+        _ = zarr.open_consolidated(zarr_mapper, mode="r")
+        store_exists = True
+    except Exception:
+        store_exists = False
 
     # ensure the time dimension is encoded as microseconds
     # which keeps it consistent with other datasets in the AWO
@@ -314,7 +339,10 @@ def append_hd5_to_s3_zarr(
             store=zarr_mapper,
             mode="a",
             append_dim="time",
-            consolidated=True,
+            # consolidate at the end of the
+            # pipeline, that improves performance
+            # and memory usage to just do it once
+            consolidated=False,
             zarr_format=2,
         )
     else:
@@ -325,7 +353,7 @@ def append_hd5_to_s3_zarr(
         ds.to_zarr(
             store=zarr_mapper,
             mode="w",
-            consolidated=True,
+            consolidated=False,
             zarr_format=2,
             encoding=time_encoding,
         )

--- a/SMAP_ETL/src/main.py
+++ b/SMAP_ETL/src/main.py
@@ -20,6 +20,7 @@ from lib import (
 )
 import minio
 import s3fs
+import zarr
 
 # filter out unnecessary warnings that we don't care about and just refer to future deprecations;
 # some of these can't actually even be addressed so the warning is pointless until future code changes
@@ -59,7 +60,7 @@ def main(
     files = get_smap_data_list_for_arizona(test_mode=test_mode)
 
     LOGGER.info(
-        "Filtering down file list to only those not previously downloaded"
+        f"Filtering down file list of {len(files)} files to only those not previously downloaded"
     )
 
     filtered_to_one_file_per_day = filter_data_to_once_a_day(files)
@@ -106,7 +107,7 @@ def main(
             hd5_file_path[0], s3_fs, bucket, s3_store_path, test_mode
         )
 
-        if test_mode and i > 5:
+        if test_mode and i > 10:
             LOGGER.warning("Stopping early since test mode was specified")
             break
 
@@ -115,6 +116,9 @@ def main(
         )
         update_checkpoint(mc, bucket, hd5_file_path[0].name)
 
+    LOGGER.info("Consolidating Zarr metadata...")
+    zarr_mapper = s3_fs.get_mapper(f"{bucket}/{s3_store_path}")
+    zarr.consolidate_metadata(zarr_mapper)
     LOGGER.info("Done!")
 
 

--- a/SMAP_ETL/src/main.py
+++ b/SMAP_ETL/src/main.py
@@ -119,7 +119,17 @@ def main(
     LOGGER.info("Consolidating Zarr metadata...")
     zarr_mapper = s3_fs.get_mapper(f"{bucket}/{s3_store_path}")
     zarr.consolidate_metadata(zarr_mapper)
-    LOGGER.info("Done!")
+
+    # assert that .zmetadata exists
+    # this is required for zarr to be usable
+    # by the national water model client which uses
+    # consolidated metadata
+    meta_path = f"{bucket}/{s3_store_path}/.zmetadata"
+    if not s3_fs.exists(meta_path):
+        raise RuntimeError(f".zmetadata not found at {meta_path}")
+
+
+LOGGER.info("Done!")
 
 
 if __name__ == "__main__":

--- a/SMAP_ETL/src/main.py
+++ b/SMAP_ETL/src/main.py
@@ -106,7 +106,9 @@ def main(
         append_hd5_to_s3_zarr(
             hd5_file_path[0], s3_fs, bucket, s3_store_path, test_mode
         )
+        # ensure the checkpoint is updated before potentially exiting early
 
+        update_checkpoint(mc, bucket, hd5_file_path[0].name)
         if test_mode and i > 10:
             LOGGER.warning("Stopping early since test mode was specified")
             break
@@ -114,7 +116,6 @@ def main(
         LOGGER.info(
             f"Updating checkpoint file with new file {hd5_file_path[0].name}"
         )
-        update_checkpoint(mc, bucket, hd5_file_path[0].name)
 
     LOGGER.info("Consolidating Zarr metadata...")
     zarr_mapper = s3_fs.get_mapper(f"{bucket}/{s3_store_path}")


### PR DESCRIPTION
- consolidate metadata once at the end
- don't list all keys to determine if the store exists
- keep only a subset of variables