### PR TITLE
Fix: prevent unnecessary network calls when loading a config object, address errors

### DIFF
--- a/ui/src/features/Tools/DateSelector/Entry.tsx
+++ b/ui/src/features/Tools/DateSelector/Entry.tsx
@@ -115,12 +115,12 @@ export const Entry: React.FC<Props> = (props) => {
   }, []);
 
   useEffect(() => {
-    if (!map) {
+    if (!map || data.length > 0 || !layer.loaded) {
       return;
     }
 
     void handleDatesFetch(map, layer);
-  }, []);
+  }, [layer.loaded]);
 
   const handleChange = (value: string | null) => {
     const index = Number(value);

--- a/ui/src/features/Tools/DateSelector/Entry.tsx
+++ b/ui/src/features/Tools/DateSelector/Entry.tsx
@@ -115,6 +115,7 @@ export const Entry: React.FC<Props> = (props) => {
   }, []);
 
   useEffect(() => {
+    // Check for data, no need to refetch
     if (!map || data.length > 0 || !layer.loaded) {
       return;
     }

--- a/ui/src/features/Tools/DateSelector/utils.ts
+++ b/ui/src/features/Tools/DateSelector/utils.ts
@@ -30,22 +30,24 @@ export const getDates = async (map: Map, layer: Layer): Promise<string[]> => {
     layer.id
   );
 
-  // For speed of access, check map first
-  const features = map.queryRenderedFeatures({
-    layers: [pointLayerId, lineLayerId, fillLayerId],
-  });
+  if (map.getLayer(pointLayerId) && map.getLayer(lineLayerId) && map.getLayer(fillLayerId)) {
+    // For speed of access, check map first
+    const features = map.queryRenderedFeatures({
+      layers: [pointLayerId, lineLayerId, fillLayerId],
+    });
 
-  if (features.length > 0) {
-    const feature = features[0];
-    return getDatesFromProperties(feature);
-  }
+    if (features.length > 0) {
+      const feature = features[0];
+      return getDatesFromProperties(feature);
+    }
 
-  // Fallback to more costly potential fetch
-  const featureCollection = await mainManager.getFeatures(layer);
-  if (featureCollection.features.length > 0) {
-    const feature = featureCollection.features[0];
+    // Fallback to more costly potential fetch
+    const featureCollection = await mainManager.getFeatures(layer);
+    if (featureCollection.features.length > 0) {
+      const feature = featureCollection.features[0];
 
-    return getDatesFromProperties(feature);
+      return getDatesFromProperties(feature);
+    }
   }
 
   throw new Error('No features found.');

--- a/ui/src/hooks/useAllLocations.ts
+++ b/ui/src/hooks/useAllLocations.ts
@@ -91,19 +91,21 @@ export const useAllLocations = (layers: Layer[]) => {
     controller.current = new AbortController();
 
     const results = await Promise.all(
-      layers.map(async (layer) => {
-        const existing = layerLocationGroups[layer.id];
+      layers
+        .filter((layer) => layer.loaded)
+        .map(async (layer) => {
+          const existing = layerLocationGroups[layer.id];
 
-        if (existing && existing.timeDataUpdated === layer.timeDataUpdated) {
-          return [layer.id, existing] as const;
-        }
+          if (existing && existing.timeDataUpdated === layer.timeDataUpdated) {
+            return [layer.id, existing] as const;
+          }
 
-        const res = await mainManager.getFeatures(layer, controller.current!.signal);
+          const res = await mainManager.getFeatures(layer, controller.current!.signal);
 
-        const group = buildGroup(layer, res.features, locations, existing);
+          const group = buildGroup(layer, res.features, locations, existing);
 
-        return [layer.id, group] as const;
-      })
+          return [layer.id, group] as const;
+        })
     );
 
     return Object.fromEntries(results);

--- a/ui/src/hooks/useSpatialSelection.ts
+++ b/ui/src/hooks/useSpatialSelection.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { useEffect, useRef } from 'react';
+import { useEffect } from 'react';
 import { bboxPolygon, featureCollection } from '@turf/turf';
 import { BBox, Feature, MultiPolygon, Polygon } from 'geojson';
 import { FilterSpecification, GeoJSONSource, LngLatBoundsLike, Map } from 'mapbox-gl';
@@ -38,35 +38,21 @@ export const useSpatialSelection = (map: Map | null) => {
   const spatialSelection = useMainStore((state) => state.spatialSelection);
   const layerCount = useMainStore((state) => state.layers.length);
 
-  const controller = useRef<AbortController>(null);
-  const isMounted = useRef(true);
-  const loadingInstance = useRef<string>(null);
-
-  useEffect(() => {
-    isMounted.current = true;
-    return () => {
-      isMounted.current = false;
-      if (controller.current) {
-        controller.current.abort('Component unmount');
-      }
-    };
-  }, []);
-
-  const fetchLowerColoradoBasin = () => {
+  const fetchLowerColoradoBasin = (signal: AbortSignal) => {
     return geoconnexService.getItem<Feature<Polygon | MultiPolygon>>('hu02', LOWER_COLORADO_ID, {
-      signal: controller.current?.signal,
+      signal,
     });
   };
 
-  const fetchUpperColoradoBasin = () => {
+  const fetchUpperColoradoBasin = (signal: AbortSignal) => {
     return geoconnexService.getItem<Feature<Polygon | MultiPolygon>>('hu02', UPPER_COLORADO_ID, {
-      signal: controller.current?.signal,
+      signal,
     });
   };
 
-  const fetchArizona = () => {
+  const fetchArizona = (signal: AbortSignal) => {
     return geoconnexService.getItem<Feature<Polygon | MultiPolygon>>('states', ARIZONA_ID, {
-      signal: controller.current?.signal,
+      signal,
     });
   };
 
@@ -96,97 +82,67 @@ export const useSpatialSelection = (map: Map | null) => {
     }
   };
 
-  const loadPredefinedBoundaries = async (map: Map) => {
-    const bboxes: { id: number; bbox: BBox }[] = [
-      { id: ARIZONA_ID_NUMERIC, bbox: getBBox(PredefinedBoundary.Arizona) },
-      { id: COLORADO_RIVER_BASIN_ID_NUMERIC, bbox: getBBox(PredefinedBoundary.ColoradoRiverBasin) },
-    ];
-    loadingInstance.current = loadingManager.add(
-      'Loading Predefined Boundary data',
-      LoadingType.Geography
-    );
-
-    const [azResult, lcResult, ucResult] = await Promise.allSettled([
-      fetchArizona(),
-      fetchLowerColoradoBasin(),
-      fetchUpperColoradoBasin(),
-    ]);
-
-    const has: PredefinedBoundary[] = [];
-
-    const features: Feature<Polygon | MultiPolygon>[] = [];
-    if (azResult.status === 'fulfilled') {
-      features.push(azResult.value);
-      has.push(PredefinedBoundary.Arizona);
-    }
-    if (lcResult.status === 'fulfilled' && ucResult.status === 'fulfilled') {
-      features.push(lcResult.value, ucResult.value);
-      has.push(PredefinedBoundary.ColoradoRiverBasin);
-    }
-
-    const spatialSelectionSource = map.getSource<GeoJSONSource>(SourceId.SpatialSelection);
-    const spatialSelectionBBoxSource = map.getSource<GeoJSONSource>(SourceId.SpatialSelectionBBox);
-
-    const detailedFeatureCollection = featureCollection(features);
-
-    const bboxFeatureCollection = featureCollection(
-      bboxes.map(({ id, bbox }) => bboxPolygon(bbox, { id }))
-    );
-
-    if (spatialSelectionSource) {
-      spatialSelectionSource.setData(detailedFeatureCollection);
-    }
-
-    if (spatialSelectionBBoxSource) {
-      spatialSelectionBBoxSource.setData(bboxFeatureCollection);
-    }
-
-    loadingInstance.current = loadingManager.remove(loadingInstance.current);
-  };
-
-  const switchPredefinedBoundaries = async (boundary: PredefinedBoundary, strict: boolean) => {
-    // There is no data that needs to refetch
-    if (layerCount === 0) {
-      return;
-    }
-
-    const getTitle = () => {
-      if (boundary === PredefinedBoundary.ColoradoRiverBasin) {
-        return 'Colorado River Basin';
-      }
-
-      return 'Arizona';
-    };
-
-    const message = `Updating data boundaries to: ${getTitle()}${strict ? ', in strict mode.' : '.'}`;
-
-    loadingInstance.current = loadingManager.add(message, LoadingType.Geography);
-    try {
-      await mainManager.applySpatialFilter([], { rethrow: true });
-    } catch (error) {
-      if ((error as Error)?.message) {
-        const _error = error as Error;
-        notificationManager.show(`${_error.message}`, NotificationVariant.Error, 10000);
-      } else if (typeof error === 'string') {
-        notificationManager.show(`${error}`, NotificationVariant.Error, 10000);
-      }
-    } finally {
-      loadingInstance.current = loadingManager.remove(loadingInstance.current);
-      notificationManager.show(
-        `Data boundaries updated to: ${getTitle()}`,
-        NotificationVariant.Success
-      );
-    }
-  };
-
   useEffect(() => {
     if (!map) {
       return;
     }
 
-    void loadPredefinedBoundaries(map);
-  }, [map]);
+    const bboxes: { id: number; bbox: BBox }[] = [
+      { id: ARIZONA_ID_NUMERIC, bbox: getBBox(PredefinedBoundary.Arizona) },
+      {
+        id: COLORADO_RIVER_BASIN_ID_NUMERIC,
+        bbox: getBBox(PredefinedBoundary.ColoradoRiverBasin),
+      },
+    ];
 
+    const loadingInstance = loadingManager.add(
+      'Loading Predefined Boundary data',
+      LoadingType.Geography
+    );
+    const controller = new AbortController();
+
+    Promise.allSettled([
+      fetchArizona(controller.signal),
+      fetchLowerColoradoBasin(controller.signal),
+      fetchUpperColoradoBasin(controller.signal),
+    ])
+      .then(([azResult, lcResult, ucResult]) => {
+        const has: PredefinedBoundary[] = [];
+        const features: Feature<Polygon | MultiPolygon>[] = [];
+
+        if (azResult.status === 'fulfilled') {
+          features.push(azResult.value);
+          has.push(PredefinedBoundary.Arizona);
+        }
+
+        if (lcResult.status === 'fulfilled' && ucResult.status === 'fulfilled') {
+          features.push(lcResult.value, ucResult.value);
+          has.push(PredefinedBoundary.ColoradoRiverBasin);
+        }
+
+        const spatialSelectionSource = map.getSource<GeoJSONSource>(SourceId.SpatialSelection);
+
+        const spatialSelectionBBoxSource = map.getSource<GeoJSONSource>(
+          SourceId.SpatialSelectionBBox
+        );
+
+        const detailedFeatureCollection = featureCollection(features);
+
+        const bboxFeatureCollection = featureCollection(
+          bboxes.map(({ id, bbox }) => bboxPolygon(bbox, { id }))
+        );
+
+        spatialSelectionSource?.setData(detailedFeatureCollection);
+        spatialSelectionBBoxSource?.setData(bboxFeatureCollection);
+      })
+      .finally(() => {
+        loadingManager.remove(loadingInstance);
+      });
+
+    return () => {
+      controller.abort('Component unmount');
+    };
+  }, [map]);
   useEffect(() => {
     if (!map) {
       return;
@@ -196,6 +152,8 @@ export const useSpatialSelection = (map: Map | null) => {
       // TODO: what needs to occur if all spatial selections cleared
       return;
     }
+
+    const controller = new AbortController();
 
     const { strict } = spatialSelection;
     if (isSpatialSelectionPredefined(spatialSelection)) {
@@ -213,17 +171,62 @@ export const useSpatialSelection = (map: Map | null) => {
         map.setFilter(LayerId.SpatialSelectionBBox, bboxFilter);
       }
 
+      // Special case: actively loading a share config object
+      // let configService.loadConfig apply the spatial filter
+      if (loadingManager.has({ type: LoadingType.Share })) {
+        return;
+      }
+
       const bbox = getBBox(boundary) as LngLatBoundsLike;
 
       map.fitBounds(bbox, { padding: 40 });
 
-      void switchPredefinedBoundaries(boundary, strict);
+      // There is no data that needs to refetch
+      if (layerCount === 0) {
+        return;
+      }
+
+      const getTitle = () => {
+        if (boundary === PredefinedBoundary.ColoradoRiverBasin) {
+          return 'Colorado River Basin';
+        }
+
+        return 'Arizona';
+      };
+
+      const message = `Updating data boundaries to: ${getTitle()}${strict ? ', in strict mode.' : '.'}`;
+
+      const loadingInstance = loadingManager.add(message, LoadingType.Geography);
+
+      // Reapply spatial filters for all layers to include new bounds
+      mainManager
+        .applySpatialFilter([], { rethrow: true, signal: controller.signal })
+        .catch((error) => {
+          if ((error as Error)?.message) {
+            const _error = error as Error;
+            notificationManager.show(`${_error.message}`, NotificationVariant.Error, 10000);
+          } else if (typeof error === 'string') {
+            notificationManager.show(`${error}`, NotificationVariant.Error, 10000);
+          }
+        })
+        .finally(() => {
+          loadingManager.remove(loadingInstance);
+          notificationManager.show(
+            `Data boundaries updated to: ${getTitle()}`,
+            NotificationVariant.Success
+          );
+        });
     }
 
+    // Toggle visibility of bounding box
     const visibility = strict ? 'none' : 'visible';
 
     if (map.getLayer(LayerId.SpatialSelectionBBox)) {
       map.setLayoutProperty(LayerId.SpatialSelectionBBox, 'visibility', visibility);
     }
+
+    return () => {
+      controller.abort('Component unmount');
+    };
   }, [map, spatialSelection]);
 };

--- a/ui/src/managers/main/Main.manager.ts
+++ b/ui/src/managers/main/Main.manager.ts
@@ -344,7 +344,7 @@ class MainManager {
 
   public async applySpatialFilter(
     drawnShapes: Feature<Polygon | MultiPolygon>[],
-    _options?: ApplySpatialFilterOptions
+    options?: ApplySpatialFilterOptions
   ): Promise<void> {
     const layers = this.store.getState().layers;
 
@@ -361,6 +361,7 @@ class MainManager {
           // addData should return the layerId
           return this.deps.dataService.addData(collectionId, layer, {
             filterFeatures: drawnShapes,
+            signal: options?.signal,
           });
         })
       );
@@ -516,6 +517,7 @@ class MainManager {
     let _color = color;
     if (parametersChanged || temporalRangeChanged || paletteChanged) {
       const drawnShapes = this.store.getState().drawnShapes;
+
       await this.deps.dataService.addData(layer.datasourceId, layer, {
         parameterNames: parameters,
         filterFeatures: drawnShapes,

--- a/ui/src/managers/types.ts
+++ b/ui/src/managers/types.ts
@@ -73,4 +73,5 @@ export type ExtendedFeatureCollection<
 
 export type ApplySpatialFilterOptions = {
   rethrow: boolean;
+  signal?: AbortSignal;
 };

--- a/ui/src/services/config.service.ts
+++ b/ui/src/services/config.service.ts
@@ -96,7 +96,8 @@ export class ConfigService {
       return;
     }
 
-    const layers = this.store.getState().layers;
+    // Unset loaded for this layer to prevent accidental reads on unloaded layer
+    const layers = this.store.getState().layers.map((layer) => ({ ...layer, loaded: false }));
     const provider = this.store.getState().provider;
     const category = this.store.getState().category;
     const collection = this.store.getState().collection;
@@ -272,20 +273,15 @@ export class ConfigService {
 
       this.map!.once('idle', async () => {
         try {
-          const dataFetches: Promise<void>[] = [];
-
           for (const layer of config.layers) {
             const sourceId = this.deps.factoryService.getSourceId(layer.datasourceId, layer.id);
             this.deps.mapService.addSource(layer.datasourceId, layer.id);
             this.deps.mapService.addLayer(layer, sourceId);
-
-            // Use applySpatialFilter, this will factor in drawn shapes but fallback
-            // to addData if none exists
-            dataFetches.push(this.deps.mainManager.applySpatialFilter(config.drawnShapes));
           }
 
-          // Fetch concurrently
-          await Promise.all(dataFetches);
+          // Use applySpatialFilter, this will factor in drawn shapes but fallback
+          // to addData if none exists
+          await this.deps.mainManager.applySpatialFilter(config.drawnShapes);
 
           // Set locations after layers are present so the map can reflect selected state
           store.setLocations(config.locations);

--- a/ui/src/services/map.service.ts
+++ b/ui/src/services/map.service.ts
@@ -442,14 +442,15 @@ export class MapService {
     V extends GeoJsonProperties = GeoJsonProperties,
   >(sourceId: string): FeatureCollection<T, V> | undefined {
     const source = this.map?.getSource(sourceId) as GeoJSONSource;
+    if (source) {
+      const data = source._data;
+      if (typeof data !== 'string') {
+        const featureCollection = turf.featureCollection<T, V>(
+          (data as FeatureCollection<T, V>).features as Feature<T, V>[]
+        );
 
-    const data = source._data;
-    if (typeof data !== 'string') {
-      const featureCollection = turf.featureCollection<T, V>(
-        (data as FeatureCollection<T, V>).features as Feature<T, V>[]
-      );
-
-      return featureCollection;
+        return featureCollection;
+      }
     }
   }
 }


### PR DESCRIPTION
### **Description**
This feature prevents unintended errors when loading a config object by correctly tracking layer load status. It also prevents duplicated network calls when loading a config object.

- [ ] Using the share feature with an EDR, Features (no params), or Grid (EDR cube col like PRISM) layer loads the data into the map
- [ ] Share feature accurately loads with a different greater area (Arizona vs Colorado River Basin). Configured using the spatial selection tool in the topbar
- [ ] Share feature works as expected with or without a drawn shape
- [ ] Only one network call (or multiples with a limit + offset) is made for each layer in the shared instance