### PR TITLE
Fix: correct the logic for detecting a feature in a drawn shape

### DIFF
--- a/ui/src/features/Map/index.tsx
+++ b/ui/src/features/Map/index.tsx
@@ -183,10 +183,14 @@ const MainMap: React.FC<Props> = (props) => {
           // Check if the edges of the drawn feature are visible
           const drawnFeature = drawnFeatures[0];
 
-          const includeDrawLayers =
+          const isWithinExtent =
             drawnFeatures.length > 0 && !drawnFeatureContainsExtent(drawnFeature, draw, map);
 
-          if (!isTopLayer(layer.id, layer.datasourceId, map, e.point, includeDrawLayers)) {
+          if (isWithinExtent) {
+            return;
+          }
+
+          if (!isTopLayer(layer.id, layer.datasourceId, map, e.point)) {
             return;
           }
 

--- a/ui/src/services/map.service.ts
+++ b/ui/src/services/map.service.ts
@@ -218,13 +218,18 @@ export class MapService {
       // Check if the edges of the drawn feature are visible
       const drawnFeature = drawnFeatures[0];
 
-      const includeDrawLayers =
+      const isWithinExtent =
         drawnFeatures.length > 0 &&
         !drawnFeatureContainsExtent(drawnFeature, this.draw!, this.map!);
 
+      // This feature is inside of drawn feature and the drawn feature is fully within the map extent
+      if (isWithinExtent) {
+        return;
+      }
+
       // As layers can be added in any order, and reordered, perform manual check to ensure popup shows
       // for top layer in visual order
-      if (!isTopLayer(layerId, collectionId, this.map!, e.point, includeDrawLayers)) {
+      if (!isTopLayer(layerId, collectionId, this.map!, e.point)) {
         return;
       }
 


### PR DESCRIPTION
### **Description:**
This is an adjustment to the existing draw logic. This checks to see if the map extent is fully within the drawn feature, if so, allows interaction with features within the draw area.

### **AC:**
- [ ] If drawn feature is fully visible within the map extent
    - [ ] Allow the drawn feature to be moved or reshaped
    - [ ] Show message to user in hover popup if user hovers over added feature: "Zoom in past drawn feature borders, or hide drawn shape, to interact with underlying features."
- [ ] If map extent is within drawn feature
    - [ ] Allow added features to be interacted with
    - [ ] Show message to user in hover popup if user hovers over drawn feature: "Zoom out to interact with this drawn feature."
- [ ] Hiding the drawn shape allows all interactions