### PR TITLE
Feature: add support for polygon series

### DIFF
--- a/ui/src/components/Charts/LineChart.tsx
+++ b/ui/src/components/Charts/LineChart.tsx
@@ -20,9 +20,9 @@ import * as echarts from 'echarts/core';
 import { CanvasRenderer } from 'echarts/renderers';
 import styles from '@/components/Charts/Charts.module.css';
 import { EChartsSeries, PrettyLabel } from '@/components/Charts/types';
-import { CoverageChartService } from '@/services/coverageJSON/coverageChart.service';
 import { TCoverageOptions, XAXisOption } from '@/services/coverageJSON/types';
 import { CoverageCollection, CoverageJSON } from '@/services/edr.service';
+import { coverageChartService } from '@/services/init/coverage.init';
 
 echarts.use([
   TitleComponent,
@@ -92,10 +92,10 @@ const LineChart = (props: Props) => {
     }
 
     data.forEach((entry, coverageIdx) => {
-      const chartData = new CoverageChartService().coverageJSONToSeries(entry, {
+      const chartData = coverageChartService.coverageJSONToSeries(entry, {
         ...parserOptions,
       });
-      console.log('chartData', chartData);
+
       let { series } = chartData;
       // TODO: determine if/how to handle differences in the x axis
       x = chartData.x;

--- a/ui/src/components/Charts/LineChart.tsx
+++ b/ui/src/components/Charts/LineChart.tsx
@@ -95,6 +95,7 @@ const LineChart = (props: Props) => {
       const chartData = new CoverageChartService().coverageJSONToSeries(entry, {
         ...parserOptions,
       });
+      console.log('chartData', chartData);
       let { series } = chartData;
       // TODO: determine if/how to handle differences in the x axis
       x = chartData.x;

--- a/ui/src/components/Table/CoverageJSON.tsx
+++ b/ui/src/components/Table/CoverageJSON.tsx
@@ -7,9 +7,9 @@ import { useMemo } from 'react';
 import { Table, Text, TextProps } from '@mantine/core';
 import { CoverageRow } from '@/components/Table/CoverageRow';
 import { TTypedOption } from '@/features/Charts/types';
-import { CoverageChartService } from '@/services/coverageJSON/coverageChart.service';
 import { TCategoryAxisOption } from '@/services/coverageJSON/types';
 import { CoverageCollection, CoverageJSON } from '@/services/edr.service';
+import { coverageChartService } from '@/services/init/coverage.init';
 
 export type Coverage = CoverageCollection | CoverageJSON | (CoverageCollection | CoverageJSON)[];
 
@@ -33,7 +33,7 @@ export const CoverageJSONTable: React.FC<Props> = (props) => {
 
     const data = Array.isArray(coverage) ? coverage[0] : coverage;
 
-    const { x } = new CoverageChartService().coverageJSONToSeries(data);
+    const { x } = coverageChartService.coverageJSONToSeries(data);
 
     return (x as TCategoryAxisOption)?.data ?? [];
   }, [coverage]);

--- a/ui/src/components/Table/CoverageRow.tsx
+++ b/ui/src/components/Table/CoverageRow.tsx
@@ -9,8 +9,8 @@ import Arrow from '@/assets/Arrow';
 import { EChartsSeries } from '@/components/Charts/types';
 import styles from '@/components/Table/Table.module.css';
 import { TTypedOption } from '@/features/Charts/types';
-import { CoverageChartService } from '@/services/coverageJSON/coverageChart.service';
 import { CoverageCollection, CoverageJSON } from '@/services/edr.service';
+import { coverageChartService } from '@/services/init/coverage.init';
 
 type Coverage = CoverageCollection | CoverageJSON | (CoverageCollection | CoverageJSON)[];
 
@@ -56,7 +56,7 @@ export const CoverageRow: React.FC<Props> = (props) => {
     const legendNames: string[] = [];
 
     data.forEach((entry, coverageIdx) => {
-      let { series } = new CoverageChartService().coverageJSONToSeries(entry, options);
+      let { series } = coverageChartService.coverageJSONToSeries(entry, options);
 
       if (useSeriesLabels) {
         const coverageLabel = seriesLabels![coverageIdx];

--- a/ui/src/services/coverageJSON/coverage.service.ts
+++ b/ui/src/services/coverageJSON/coverage.service.ts
@@ -20,7 +20,7 @@ export class CoverageService {
     return length;
   }
 
-  getValues(coverage: CoverageJSON, options?: TCoverageOptions): TValues {
+  getRange(coverage: CoverageJSON, options?: TCoverageOptions): TValues {
     const filteredRanges = Object.entries(coverage.ranges).filter(([parameterId]) => {
       if (options?.chosenParameter) {
         const parameterEntry = coverage.parameters[parameterId];
@@ -77,7 +77,7 @@ export class CoverageService {
     return coverage.domain.domainType ?? coverage?.domainType ?? '';
   }
 
-  getCurrentValuesConstructor(count: number, values: TValues, xCount: number, yCount: number) {
+  getCurrentRangeValueConstructor(count: number, values: TValues, xCount: number, yCount: number) {
     const keys = Object.keys(values);
 
     return (i: number, j: number): TValues => {

--- a/ui/src/services/coverageJSON/coverageChart.service.ts
+++ b/ui/src/services/coverageJSON/coverageChart.service.ts
@@ -4,7 +4,7 @@
  */
 
 import { EChartsSeries } from '@/components/Charts/types';
-import notificationManager from '@/managers/Notification.init';
+import NotificationManager from '@/managers/Notification.manager';
 import { CoverageService } from '@/services/coverageJSON/coverage.service';
 import {
   TChartData,
@@ -19,7 +19,18 @@ import { NotificationVariant } from '@/stores/session/types';
 import { isAxesValues, isCoverageCollection } from '@/utils/isTypeObject';
 import { getParameterUnit } from '@/utils/parameters';
 
+type CoverageChartServiceDependencies = {
+  notificationManager: NotificationManager;
+};
+
 export class CoverageChartService extends CoverageService {
+  private deps: CoverageChartServiceDependencies;
+
+  constructor(deps: CoverageChartServiceDependencies) {
+    super();
+    this.deps = deps;
+  }
+
   private associateDataWithTime(
     values: (string | number | null)[],
     times: (string | number)[]
@@ -112,11 +123,13 @@ export class CoverageChartService extends CoverageService {
     const { t, x: xObj, y: yObj } = this.getAxes(coverage);
 
     if (this.isSegments(xObj) && this.isSegments(yObj)) {
-      notificationManager.show(
-        `Domain type ${coverage.domain.domainType}, sub-type segments is not currently supported.`,
-        NotificationVariant.Error,
-        10000
-      );
+      if (this.deps.notificationManager) {
+        this.deps.notificationManager.show(
+          `Domain type ${coverage.domain.domainType}, sub-type segments is not currently supported.`,
+          NotificationVariant.Error,
+          10000
+        );
+      }
       return [];
     }
 
@@ -131,7 +144,13 @@ export class CoverageChartService extends CoverageService {
     const coverageParameters = coverage.parameters ?? options?.parameters;
 
     if (!coverage.ranges) {
-      notificationManager.show('Missing ranges in coverage data', NotificationVariant.Error, 10000);
+      if (this.deps.notificationManager) {
+        this.deps.notificationManager.show(
+          'Missing ranges in coverage data',
+          NotificationVariant.Error,
+          10000
+        );
+      }
       return [];
     }
 
@@ -195,12 +214,14 @@ export class CoverageChartService extends CoverageService {
     const dates = (coverage.domain.axes.t as { values: string[] }).values;
     const coverageParameters = coverage.parameters ?? options?.parameters;
 
-    if (!coverage.ranges || !dates) {
-      notificationManager.show(
-        'Missing ranges or date axis in coverage data',
-        NotificationVariant.Error,
-        10000
-      );
+    if (!coverage.ranges || Object.keys(coverage.ranges).length === 0 || !dates) {
+      if (this.deps.notificationManager) {
+        this.deps.notificationManager.show(
+          'Missing ranges or date axis in coverage data. There may be no data for this date range.',
+          NotificationVariant.Error,
+          10000
+        );
+      }
       return [];
     }
 
@@ -334,12 +355,25 @@ export class CoverageChartService extends CoverageService {
   private processSingleton(coverage: CoverageJSON, options?: TCoverageOptions) {
     const { t, x: xObj, y: yObj } = this.getAxes(coverage);
 
+    if (!coverage.ranges || Object.keys(coverage.ranges).length === 0) {
+      if (this.deps.notificationManager) {
+        this.deps.notificationManager.show(
+          'Missing ranges in coverage data. There may be no data for this date range.',
+          NotificationVariant.Error,
+          10000
+        );
+      }
+      return [];
+    }
+
     if (this.isSegments(xObj) && this.isSegments(yObj)) {
-      notificationManager.show(
-        `Domain type ${coverage.domain.domainType}, sub-type segments is not currently supported.`,
-        NotificationVariant.Error,
-        10000
-      );
+      if (this.deps.notificationManager) {
+        this.deps.notificationManager.show(
+          `Domain type ${coverage.domain.domainType}, sub-type segments is not currently supported.`,
+          NotificationVariant.Error,
+          10000
+        );
+      }
       return [];
     }
 
@@ -381,11 +415,13 @@ export class CoverageChartService extends CoverageService {
     if (['Polygon', 'Point'].includes(domainType)) {
       return this.processSingleton(coverage, options);
     }
-    notificationManager.show(
-      `Domain type ${domainType} is not currently supported.`,
-      NotificationVariant.Error,
-      10000
-    );
+    if (this.deps.notificationManager) {
+      this.deps.notificationManager.show(
+        `Domain type ${domainType} is not currently supported.`,
+        NotificationVariant.Error,
+        10000
+      );
+    }
     return [];
   }
 

--- a/ui/src/services/coverageJSON/coverageChart.service.ts
+++ b/ui/src/services/coverageJSON/coverageChart.service.ts
@@ -41,7 +41,7 @@ export class CoverageChartService extends CoverageService {
     const xLength = xValues.length;
     const yLength = yValues.length;
 
-    const getCurrentValues = this.getCurrentValuesConstructor(count, values, xLength, yLength);
+    const getCurrentValues = this.getCurrentRangeValueConstructor(count, values, xLength, yLength);
     let id = 1;
 
     return (x: number, y: number) => {
@@ -82,7 +82,7 @@ export class CoverageChartService extends CoverageService {
     coverage: CoverageJSON,
     options?: TCoverageOptions
   ): EChartsSeries[] {
-    let values: TValues | null = this.getValues(coverage, options);
+    let values: TValues | null = this.getRange(coverage, options);
 
     const series: EChartsSeries[] = [];
 
@@ -188,7 +188,7 @@ export class CoverageChartService extends CoverageService {
     return series;
   }
 
-  private processPointSeries(
+  private processSeries(
     coverage: CoverageJSON,
     options: TCoverageOptions = { axisStyle: 'values' }
   ) {
@@ -252,7 +252,7 @@ export class CoverageChartService extends CoverageService {
 
     return series;
   }
-  private addPointValuesConstructor(
+  private addSingletonValuesConstructor(
     xValues: number[],
     yValues: number[],
     series: EChartsSeries[],
@@ -266,7 +266,7 @@ export class CoverageChartService extends CoverageService {
     const xLength = xValues.length;
     const yLength = yValues.length;
 
-    const getCurrentValues = this.getCurrentValuesConstructor(count, values, xLength, yLength);
+    const getCurrentValues = this.getCurrentRangeValueConstructor(count, values, xLength, yLength);
     let id = 1;
 
     return (x: number, y: number) => {
@@ -300,20 +300,20 @@ export class CoverageChartService extends CoverageService {
     };
   }
 
-  private processPointValues(
+  private processSingletonValues(
     timesObj: CoverageAxesValues,
     xObj: CoverageAxesValues,
     yObj: CoverageAxesValues,
     coverage: CoverageJSON,
     options?: TCoverageOptions
   ): EChartsSeries[] {
-    let values: TValues | null = this.getValues(coverage, options);
+    let values: TValues | null = this.getRange(coverage, options);
 
     const series: EChartsSeries[] = [];
 
     const coverageParameters = coverage.parameters;
 
-    const addPoint = this.addPointValuesConstructor(
+    const addPoint = this.addSingletonValuesConstructor(
       xObj.values as number[],
       yObj.values as number[],
       series,
@@ -331,7 +331,7 @@ export class CoverageChartService extends CoverageService {
 
     return series;
   }
-  private processPoint(coverage: CoverageJSON, options?: TCoverageOptions) {
+  private processSingleton(coverage: CoverageJSON, options?: TCoverageOptions) {
     const { t, x: xObj, y: yObj } = this.getAxes(coverage);
 
     if (this.isSegments(xObj) && this.isSegments(yObj)) {
@@ -344,7 +344,7 @@ export class CoverageChartService extends CoverageService {
     }
 
     if (this.isValues(xObj) && this.isValues(yObj)) {
-      return this.processPointValues(t, xObj, yObj, coverage, options);
+      return this.processSingletonValues(t, xObj, yObj, coverage, options);
     }
 
     return [];
@@ -366,8 +366,8 @@ export class CoverageChartService extends CoverageService {
   private coverageToSeries(coverage: CoverageJSON, options?: TCoverageOptions) {
     const domainType = this.getDomainType(coverage);
 
-    if (domainType === 'PointSeries') {
-      return this.processPointSeries(coverage, options);
+    if (['PolygonSeries', 'PointSeries'].includes(domainType)) {
+      return this.processSeries(coverage, options);
     }
 
     if (domainType === 'VerticalProfile') {
@@ -378,8 +378,8 @@ export class CoverageChartService extends CoverageService {
       return this.processGrid(coverage, options);
     }
 
-    if (domainType === 'Point') {
-      return this.processPoint(coverage, options);
+    if (['Polygon', 'Point'].includes(domainType)) {
+      return this.processSingleton(coverage, options);
     }
     notificationManager.show(
       `Domain type ${domainType} is not currently supported.`,
@@ -466,7 +466,7 @@ export class CoverageChartService extends CoverageService {
       };
     }
 
-    if (['PointSeries', 'Grid'].includes(domainType)) {
+    if (['PolygonSeries', 'PointSeries', 'Polygon', 'Point', 'Grid'].includes(domainType)) {
       const dates = this.extractDates(coverage);
 
       if (axisStyle === 'time') {

--- a/ui/src/services/coverageJSON/coverageGeo.service.ts
+++ b/ui/src/services/coverageJSON/coverageGeo.service.ts
@@ -35,7 +35,7 @@ export class CoverageGeoService extends CoverageService {
     const xLength = xValues.length;
     const yLength = yValues.length;
 
-    const getCurrentValues = this.getCurrentValuesConstructor(count, values, xLength, yLength);
+    const getCurrentValues = this.getCurrentRangeValueConstructor(count, values, xLength, yLength);
     let id = 1;
 
     return (x: number, y: number) => {
@@ -71,7 +71,7 @@ export class CoverageGeoService extends CoverageService {
     coverage: CoverageJSON,
     currentId?: number
   ): FeatureCollection<Polygon> {
-    let values: TValues | null = this.getValues(coverage);
+    let values: TValues | null = this.getRange(coverage);
 
     const featureCollection = getDefaultGeoJSON<Polygon>();
 
@@ -108,7 +108,7 @@ export class CoverageGeoService extends CoverageService {
   ) {
     const count = times.length;
 
-    const getCurrentValues = this.getCurrentValuesConstructor(count, values, xCount, yCount);
+    const getCurrentValues = this.getCurrentRangeValueConstructor(count, values, xCount, yCount);
 
     let id = 1;
 
@@ -148,7 +148,7 @@ export class CoverageGeoService extends CoverageService {
     const xLength = this.getLength(xObj);
     const yLength = this.getLength(yObj);
 
-    let values: TValues | null = this.getValues(coverage);
+    let values: TValues | null = this.getRange(coverage);
 
     const featureCollection = getDefaultGeoJSON<Polygon>();
 
@@ -218,7 +218,7 @@ export class CoverageGeoService extends CoverageService {
     const xLength = xValues.length;
     const yLength = yValues.length;
 
-    const getCurrentValues = this.getCurrentValuesConstructor(count, values, xLength, yLength);
+    const getCurrentValues = this.getCurrentRangeValueConstructor(count, values, xLength, yLength);
     let id = 1;
 
     return (x: number, y: number) => {
@@ -256,7 +256,7 @@ export class CoverageGeoService extends CoverageService {
     coverage: CoverageJSON,
     id?: number
   ): FeatureCollection<Point> {
-    let values: TValues | null = this.getValues(coverage);
+    let values: TValues | null = this.getRange(coverage);
 
     const featureCollection = getDefaultGeoJSON<Point>();
 

--- a/ui/src/services/init/coverage.init.ts
+++ b/ui/src/services/init/coverage.init.ts
@@ -1,0 +1,9 @@
+/**
+ * Copyright 2026 Lincoln Institute of Land Policy
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import notificationManager from '@/managers/Notification.init';
+import { CoverageChartService } from '@/services/coverageJSON/coverageChart.service';
+
+export const coverageChartService = new CoverageChartService({ notificationManager });


### PR DESCRIPTION
### **Description**
Adds support for PolygonSeries & Polygon coverage types to the coverage chart service. Also makes the notificationManager an injected dependency, cleans up the semantic naming of certain functions, and adds an additional notification for QOL.

### **AC**

- [ ] Add an instance of " GRACE/FO-derived Lower Colorado Basin Groundwater Storage Levels Changes 1", select a param
    - [ ] Without changing the default dates, open the detailed popup. Expect no line chart values, but also an error warning that there is no data for this date range
    - [ ] Change the dates to something like "02/01/2008" -> "05/01/2009", expect a line chart