### PR TITLE
Feature: apply category filter to parameter selects

### DIFF
--- a/ui/src/features/Panel/Datasets/Dataset/Content.tsx
+++ b/ui/src/features/Panel/Datasets/Dataset/Content.tsx
@@ -9,7 +9,8 @@ import Select from '@/components/Select';
 import styles from '@/features/Panel/Panel.module.css';
 import { useLoading } from '@/hooks/useLoading';
 import { ICollection } from '@/services/edr.service';
-import { Layer } from '@/stores/main/types';
+import useMainStore from '@/stores/main';
+import { Category, Layer } from '@/stores/main/types';
 import { CollectionType, getCollectionType } from '@/utils/collection';
 import { getParameterUnit } from '@/utils/parameters';
 
@@ -30,17 +31,21 @@ export const Content: React.FC<Props> = (props) => {
     isParameterSelectionOverLimit,
   } = props;
 
+  const category = useMainStore((state) => state.category);
+  const parameterGroupMembers = useMainStore((state) => state.parameterGroupMembers);
+
   const [data, setData] = useState<ComboboxData>();
 
   const [datasetLink, setDatasetLink] = useState('');
   const [sourceLink, setSourceLink] = useState('');
   const [documentationLink, setDocumentationLink] = useState('');
   const [collectionType, setCollectionType] = useState<CollectionType>(CollectionType.Unknown);
+  const [categoryFilterExcludesCollection, setCategoryFilterExcludesCollection] = useState(false);
 
   const { isFetchingCollections } = useLoading();
 
   useEffect(() => {
-    if (isFetchingCollections || data) {
+    if (isFetchingCollections) {
       return;
     }
 
@@ -60,7 +65,17 @@ export const Content: React.FC<Props> = (props) => {
 
     const paramObjects = Object.values(dataset?.parameter_names ?? {});
 
+    let categoryFilter: string[] = [];
+    if (category) {
+      const validGroups = parameterGroupMembers?.[category.label];
+
+      categoryFilter = validGroups?.[dataset.id] ?? [];
+    }
+
+    setCategoryFilterExcludesCollection(categoryFilter.length === 0);
+
     const newData = paramObjects
+      .filter((object) => categoryFilter.length === 0 || categoryFilter.includes(object.id))
       .map((object) => {
         const unit = getParameterUnit(object);
 
@@ -71,7 +86,17 @@ export const Content: React.FC<Props> = (props) => {
       })
       .sort((a, b) => a.label.localeCompare(b.label));
     setData(newData);
-  }, [isFetchingCollections, dataset]);
+  }, [category, isFetchingCollections, dataset]);
+
+  const getCategoryNote = (
+    categoryFilterExcludesCollection: boolean,
+    category: Category | null
+  ) => {
+    if (categoryFilterExcludesCollection) {
+      return 'Selected category does not apply to this dataset. Showing all parameters.';
+    }
+    return category ? `Showing parameters within selected category: ${category.label}` : null;
+  };
 
   const getParameterError = () => {
     if (parameterLimit && isParameterSelectionOverLimit) {
@@ -114,6 +139,11 @@ export const Content: React.FC<Props> = (props) => {
             Parameters can be further customized for each layer instance within that layer's
             controls.
           </Text>
+          {category && (
+            <Text c="dimmed" size="sm">
+              {getCategoryNote(categoryFilterExcludesCollection, category)}
+            </Text>
+          )}
         </>
       )}
 

--- a/ui/src/features/Panel/Layers/Layer/Tabs/Data.tsx
+++ b/ui/src/features/Panel/Layers/Layer/Tabs/Data.tsx
@@ -48,6 +48,7 @@ type Props = {
   collectionType: CollectionType;
   parameterOptions: ComboboxData | undefined;
   category: Category | null;
+  categoryFilterExcludesCollection: boolean;
   attributes: Attributes;
   attributeHandlers: AttributeHandlers;
   updateHandlers: UpdateHandlers;
@@ -60,6 +61,7 @@ export const Data: React.FC<Props> = (props) => {
     collectionType,
     parameterOptions,
     category,
+    categoryFilterExcludesCollection,
     attributes: { from, to, parameters, paletteDefinition, color },
     attributeHandlers: {
       onFromChange,
@@ -92,10 +94,15 @@ export const Data: React.FC<Props> = (props) => {
 
   const { isLoadingGeography } = useLoading();
 
-  const getCategoryNote = (category: Category | null) => {
+  const getCategoryNote = (
+    categoryFilterExcludesCollection: boolean,
+    category: Category | null
+  ) => {
+    if (categoryFilterExcludesCollection) {
+      return 'Selected category does not apply to this dataset. Showing all parameters.';
+    }
     return category ? `Showing parameters within selected category: ${category.label}` : null;
   };
-
   const showDateInput = collectionType === CollectionType.EDRGrid;
 
   return (
@@ -160,7 +167,7 @@ export const Data: React.FC<Props> = (props) => {
         />
         {category && (
           <Text c="dimmed" size="sm">
-            {getCategoryNote(category)}
+            {getCategoryNote(categoryFilterExcludesCollection, category)}
           </Text>
         )}
         {showPalette && parameterOptions && (

--- a/ui/src/features/Panel/Layers/Layer/Tabs/Data.tsx
+++ b/ui/src/features/Panel/Layers/Layer/Tabs/Data.tsx
@@ -17,7 +17,7 @@ import { Popover } from '@/features/Panel/Layers/Layer/Color/Popover';
 import styles from '@/features/Panel/Panel.module.css';
 import { useLayerValidation } from '@/hooks/useLayerValidation';
 import { useLoading } from '@/hooks/useLoading';
-import { Layer } from '@/stores/main/types';
+import { Category, Layer } from '@/stores/main/types';
 import { CollectionType } from '@/utils/collection';
 import { isSamePalette, isValidPalette } from '@/utils/colors';
 
@@ -47,6 +47,7 @@ type Props = {
   isLoading: boolean;
   collectionType: CollectionType;
   parameterOptions: ComboboxData | undefined;
+  category: Category | null;
   attributes: Attributes;
   attributeHandlers: AttributeHandlers;
   updateHandlers: UpdateHandlers;
@@ -58,6 +59,7 @@ export const Data: React.FC<Props> = (props) => {
     isLoading,
     collectionType,
     parameterOptions,
+    category,
     attributes: { from, to, parameters, paletteDefinition, color },
     attributeHandlers: {
       onFromChange,
@@ -89,6 +91,10 @@ export const Data: React.FC<Props> = (props) => {
   });
 
   const { isLoadingGeography } = useLoading();
+
+  const getCategoryNote = (category: Category | null) => {
+    return category ? `Showing parameters within selected category: ${category.label}` : null;
+  };
 
   const showDateInput = collectionType === CollectionType.EDRGrid;
 
@@ -152,6 +158,11 @@ export const Data: React.FC<Props> = (props) => {
           onChange={onParametersChange}
           error={getParameterError()}
         />
+        {category && (
+          <Text c="dimmed" size="sm">
+            {getCategoryNote(category)}
+          </Text>
+        )}
         {showPalette && parameterOptions && (
           <Group align="flex-start" gap="var(--default-spacing)" mt="var(--default-spacing)">
             <Text size="sm" fw={700}>

--- a/ui/src/features/Panel/Layers/Layer/index.tsx
+++ b/ui/src/features/Panel/Layers/Layer/index.tsx
@@ -20,6 +20,7 @@ import { useLoading } from '@/hooks/useLoading';
 import loadingManager from '@/managers/Loading.init';
 import notificationManager from '@/managers/Notification.init';
 import { collectionService, mainManager } from '@/services/init';
+import useMainStore from '@/stores/main';
 import { Layer as LayerType } from '@/stores/main/types';
 import { LoadingType, NotificationVariant } from '@/stores/session/types';
 import { CollectionType, getCollectionType } from '@/utils/collection';
@@ -46,6 +47,9 @@ const Layer: React.FC<Props> = (props) => {
     includedTabs = ['settings', 'data', 'tools', 'search', 'label', 'locations'],
     flatTabs = false,
   } = props;
+
+  const category = useMainStore((state) => state.category);
+  const parameterGroupMembers = useMainStore((state) => state.parameterGroupMembers);
 
   const [name, setName] = useState(layer.name);
   const debouncedName = useDebounce(name, 300);
@@ -95,7 +99,15 @@ const Layer: React.FC<Props> = (props) => {
 
       const paramObjects = Object.values(collection?.parameter_names ?? {});
 
+      let categoryFilter: string[] = [];
+      if (category) {
+        const validGroups = parameterGroupMembers[category.label];
+
+        categoryFilter = validGroups[collection.id];
+      }
+
       const data = paramObjects
+        .filter((object) => categoryFilter.length === 0 || categoryFilter.includes(object.id))
         .map((object) => {
           const unit = getParameterUnit(object);
 
@@ -358,6 +370,7 @@ const Layer: React.FC<Props> = (props) => {
             isLoading={isLoading}
             parameterOptions={parameterOptions}
             collectionType={collectionType}
+            category={category}
             attributes={{ parameters, from, to, paletteDefinition, color }}
             attributeHandlers={{
               onFromChange: handleFromChange,

--- a/ui/src/features/Panel/Layers/Layer/index.tsx
+++ b/ui/src/features/Panel/Layers/Layer/index.tsx
@@ -63,6 +63,7 @@ const Layer: React.FC<Props> = (props) => {
   const [collectionType, setCollectionType] = useState<CollectionType>(CollectionType.Unknown);
   const [paletteDefinition, setPaletteDefinition] = useState(layer.paletteDefinition);
 
+  const [categoryFilterExcludesCollection, setCategoryFilterExcludesCollection] = useState(false);
   const [parameterOptions, setParameterOptions] = useState<ComboboxData>();
   const [isLoading, setIsLoading] = useState(false);
 
@@ -87,7 +88,7 @@ const Layer: React.FC<Props> = (props) => {
     });
 
   useEffect(() => {
-    if (isFetchingCollections || parameterOptions) {
+    if (isFetchingCollections) {
       return;
     }
 
@@ -101,10 +102,12 @@ const Layer: React.FC<Props> = (props) => {
 
       let categoryFilter: string[] = [];
       if (category) {
-        const validGroups = parameterGroupMembers[category.label];
+        const validGroups = parameterGroupMembers?.[category.label];
 
-        categoryFilter = validGroups[collection.id];
+        categoryFilter = validGroups?.[collection.id] ?? [];
       }
+
+      setCategoryFilterExcludesCollection(categoryFilter.length === 0);
 
       const data = paramObjects
         .filter((object) => categoryFilter.length === 0 || categoryFilter.includes(object.id))
@@ -119,7 +122,7 @@ const Layer: React.FC<Props> = (props) => {
         .sort((a, b) => a.label.localeCompare(b.label));
       setParameterOptions(data);
     }
-  }, [isFetchingCollections]);
+  }, [category, isFetchingCollections]);
 
   // If user updates color through the legend, update it here
   useEffect(() => {
@@ -371,6 +374,7 @@ const Layer: React.FC<Props> = (props) => {
             parameterOptions={parameterOptions}
             collectionType={collectionType}
             category={category}
+            categoryFilterExcludesCollection={categoryFilterExcludesCollection}
             attributes={{ parameters, from, to, paletteDefinition, color }}
             attributeHandlers={{
               onFromChange: handleFromChange,

--- a/ui/src/managers/main/Main.manager.ts
+++ b/ui/src/managers/main/Main.manager.ts
@@ -403,7 +403,7 @@ class MainManager {
   private createParameterGroupMembers(parameterGroups: ParameterGroup[]): void {
     const parameterGroupMembers: ParameterGroupMembers = {};
     parameterGroups.forEach((parameterGroup) => {
-      parameterGroupMembers[parameterGroup.label] = Object.keys(parameterGroup.members);
+      parameterGroupMembers[parameterGroup.label] = parameterGroup.members;
     });
 
     this.store.getState().setParameterGroupMembers(parameterGroupMembers);

--- a/ui/src/stores/main/types.ts
+++ b/ui/src/stores/main/types.ts
@@ -151,7 +151,7 @@ export type TSearch = {
   matchedLocations: string[];
 };
 
-export type ParameterGroupMembers = Record<string, string[]>;
+export type ParameterGroupMembers = Record<string, Record<string, string[]>>;
 
 export type MainState = {
   geographyFilter: any | null;

--- a/ui/src/stores/main/types.ts
+++ b/ui/src/stores/main/types.ts
@@ -151,7 +151,7 @@ export type TSearch = {
   matchedLocations: string[];
 };
 
-export type ParameterGroupMembers = Partial<Record<string, Record<string, string[]>>>;
+export type ParameterGroupMembers = Record<string, Partial<Record<string, string[]>>>;
 
 export type MainState = {
   geographyFilter: any | null;

--- a/ui/src/stores/main/types.ts
+++ b/ui/src/stores/main/types.ts
@@ -151,7 +151,7 @@ export type TSearch = {
   matchedLocations: string[];
 };
 
-export type ParameterGroupMembers = Record<string, Record<string, string[]>>;
+export type ParameterGroupMembers = Partial<Record<string, Record<string, string[]>>>;
 
 export type MainState = {
   geographyFilter: any | null;

--- a/ui/src/utils/filterCollections.ts
+++ b/ui/src/utils/filterCollections.ts
@@ -33,7 +33,7 @@ export const filterCollections = (
     filterFunctions.push(filterFunction);
   }
   if (category) {
-    const categoryMembers = parameterGroupMembers[category.value];
+    const categoryMembers = Object.keys(parameterGroupMembers[category.value]);
     filterFunctions.push((collection) => categoryMembers.includes(collection.id));
   }
 


### PR DESCRIPTION
### **Description**
Applies the selected category filter to parameter select elements in the dataset and layer controls.

### **AC**
- [ ] Selecting a category filters the options in the parameter dropdowns, and shows a corresponding message
- [ ] If a layer is created from a dataset that is filtered out by the category filter, all parameter options are shown with a corresponding message 