### PR TITLE
Feature: update geocoder based on selected spatial boundary

### DIFF
--- a/ui/src/consts/bbox.ts
+++ b/ui/src/consts/bbox.ts
@@ -3,8 +3,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { BBox } from 'geojson';
 import { PredefinedBoundary } from '@/stores/main/types';
+
+// Narrower type than `geojson` type
+type BBox = [number, number, number, number];
 
 export const ArizonaBBox: BBox = [-114.81651, 31.332176999999998, -109.045223, 37.004259999999995];
 
@@ -13,8 +15,8 @@ export const UpperColoradoRegionBBox: BBox = [-112.328642, 35.5600937, -105.6265
 
 export const ColoradoRiverBasinBBox: BBox = [-115.7059785, 29.8385906, -105.6265665, 43.4521139];
 
-export const getBBox = (which: PredefinedBoundary): BBox => {
-  switch (which) {
+export const getBBox = (boundary: PredefinedBoundary): BBox => {
+  switch (boundary) {
     case PredefinedBoundary.ColoradoRiverBasin:
       return ColoradoRiverBasinBBox;
 
@@ -22,4 +24,16 @@ export const getBBox = (which: PredefinedBoundary): BBox => {
     default:
       return ArizonaBBox;
   }
+};
+
+export const getStateList = (boundary: PredefinedBoundary, strict: boolean): string[] => {
+  if (boundary === PredefinedBoundary.ColoradoRiverBasin) {
+    const states = ['arizona', 'new mexico', 'colorado', 'utah', 'wyoming', 'nevada', 'california'];
+    if (!strict) {
+      states.push('idaho');
+    }
+    return states;
+  }
+
+  return ['arizona'];
 };

--- a/ui/src/features/Map/index.tsx
+++ b/ui/src/features/Map/index.tsx
@@ -9,11 +9,17 @@ import { useMediaQuery } from '@mantine/hooks';
 import Map from '@/components/Map';
 import { basemaps } from '@/components/Map/consts';
 import { LayerType } from '@/components/Map/types';
+import { getBBox } from '@/consts/bbox';
 import { useMap } from '@/contexts/MapContexts';
 import { layerDefinitions, MAP_ID } from '@/features/Map/config';
-import { DEFAULT_BBOX, drawLayers, INITIAL_CENTER, INITIAL_ZOOM } from '@/features/Map/consts';
+import { drawLayers, INITIAL_CENTER, INITIAL_ZOOM } from '@/features/Map/consts';
 import { sourceConfigs, SourceId } from '@/features/Map/sources';
-import { drawnFeatureContainsExtent, getSelectedColor, getSortKey } from '@/features/Map/utils';
+import {
+  drawnFeatureContainsExtent,
+  getGeocoderFilterFunction,
+  getSelectedColor,
+  getSortKey,
+} from '@/features/Map/utils';
 import { showGraphPopup } from '@/features/Popup/utils';
 import { useSpatialSelection } from '@/hooks/useSpatialSelection';
 import notificationManager from '@/managers/Notification.init';
@@ -26,7 +32,7 @@ import {
   popupService,
 } from '@/services/init';
 import useMainStore from '@/stores/main';
-import { Location } from '@/stores/main/types';
+import { Location, PredefinedBoundary } from '@/stores/main/types';
 import useSessionStore from '@/stores/session';
 import { groupLocationIdsByLayer } from '@/utils/groupLocationsByCollection';
 import { isTopLayer } from '@/utils/isTopLayer';
@@ -68,7 +74,7 @@ const MainMap: React.FC<Props> = (props) => {
 
   const mobile = useMediaQuery('(max-width: 899px)');
 
-  useSpatialSelection(map);
+  useSpatialSelection(map, geocoder);
 
   useEffect(() => {
     return () => {
@@ -438,14 +444,12 @@ const MainMap: React.FC<Props> = (props) => {
         }}
         draw={{ clickBuffer: 5, touchEnabled: true, displayControlsDefault: false }}
         geocoder={{
-          bbox: DEFAULT_BBOX, // limit to Arizona
+          bbox: getBBox(PredefinedBoundary.Arizona), // limit to Arizona
           countries: 'us', // exclude non-US cities in bbox
           placeholder: 'Search for a location',
           flyTo: false,
           trackProximity: false,
-          filter: (item) => {
-            return item.place_name.toLowerCase().includes('arizona');
-          },
+          filter: getGeocoderFilterFunction(PredefinedBoundary.Arizona, true),
         }}
         eventHandlers={{
           doubleClickZoom: false,

--- a/ui/src/features/Map/utils.ts
+++ b/ui/src/features/Map/utils.ts
@@ -4,11 +4,13 @@
  */
 
 import MapboxDraw from '@mapbox/mapbox-gl-draw';
+import MapboxGeocoder from '@mapbox/mapbox-gl-geocoder';
 import { bboxPolygon, booleanContains } from '@turf/turf';
 import { ExpressionSpecification, GeoJSONFeature, Map } from 'mapbox-gl';
+import { getStateList } from '@/consts/bbox';
 import { idStoreProperty } from '@/consts/collections';
 import { LayerId, SubLayerId } from '@/features/Map/config';
-import { Location } from '@/stores/main/types';
+import { Location, PredefinedBoundary } from '@/stores/main/types';
 
 const getSimpleSelectMessage = (layerId: LayerId | SubLayerId): string => {
   switch (layerId) {
@@ -185,4 +187,11 @@ export const loadImages = (map: Map) => {
   // }
 
   map.triggerRepaint();
+};
+
+export const getGeocoderFilterFunction = (boundary: PredefinedBoundary, strict: boolean) => {
+  const list = getStateList(boundary, strict);
+  return (item: MapboxGeocoder.Result) => {
+    return list.some((state) => item.place_name.toLowerCase().includes(state));
+  };
 };

--- a/ui/src/features/Tools/Geocoder.tsx
+++ b/ui/src/features/Tools/Geocoder.tsx
@@ -7,6 +7,7 @@ import { useEffect, useRef } from 'react';
 import { useMap } from '@/contexts/MapContexts';
 import { MAP_ID } from '@/features/Map/config';
 import styles from '@/features/Tools/Tools.module.css';
+import useSessionStore from '@/stores/session';
 
 // IMPORTANT NOTE: geocoder can only support one mounted instance
 // if changing screen size between mobile and desktop, the geocoder mounted
@@ -16,6 +17,8 @@ export const Geocoder: React.FC = () => {
 
   const { map, geocoder } = useMap(MAP_ID);
 
+  const setOverlay = useSessionStore((state) => state.setOverlay);
+
   useEffect(() => {
     if (!map || !geocoder || !ref.current) {
       return;
@@ -24,9 +27,20 @@ export const Geocoder: React.FC = () => {
     ref.current.innerHTML = '';
     ref.current.appendChild(geocoder.onAdd(map));
 
+    const clearOverlay = () => setOverlay(null);
+
+    const input = ref.current.querySelector('.mapboxgl-ctrl-geocoder--input');
+    if (input) {
+      input.addEventListener('focus', clearOverlay);
+    }
+
     return () => {
       if (ref.current) {
         ref.current.innerHTML = '';
+        const input = ref.current.querySelector('.mapboxgl-ctrl-geocoder--input');
+        if (input) {
+          input.removeEventListener('focus', clearOverlay);
+        }
         ref.current = null;
       }
     };

--- a/ui/src/hooks/useSpatialSelection.ts
+++ b/ui/src/hooks/useSpatialSelection.ts
@@ -4,12 +4,14 @@
  */
 
 import { useEffect } from 'react';
+import MapboxGeocoder from '@mapbox/mapbox-gl-geocoder';
 import { bboxPolygon, featureCollection } from '@turf/turf';
 import { BBox, Feature, MultiPolygon, Polygon } from 'geojson';
-import { FilterSpecification, GeoJSONSource, LngLatBoundsLike, Map } from 'mapbox-gl';
+import { FilterSpecification, GeoJSONSource, Map } from 'mapbox-gl';
 import { getBBox } from '@/consts/bbox';
 import { LayerId } from '@/features/Map/config';
 import { SourceId } from '@/features/Map/sources';
+import { getGeocoderFilterFunction } from '@/features/Map/utils';
 import loadingManager from '@/managers/Loading.init';
 import notificationManager from '@/managers/Notification.init';
 import { mainManager } from '@/services/init';
@@ -34,7 +36,7 @@ export const ARIZONA_ID_NUMERIC = Number(ARIZONA_ID);
  * @param map Map | null
  * @returns void
  */
-export const useSpatialSelection = (map: Map | null) => {
+export const useSpatialSelection = (map: Map | null, geocoder: MapboxGeocoder | null) => {
   const spatialSelection = useMainStore((state) => state.spatialSelection);
   const layerCount = useMainStore((state) => state.layers.length);
 
@@ -171,13 +173,19 @@ export const useSpatialSelection = (map: Map | null) => {
         map.setFilter(LayerId.SpatialSelectionBBox, bboxFilter);
       }
 
+      const bbox = getBBox(boundary);
+
+      if (geocoder) {
+        geocoder.setBbox(bbox);
+        const filterFunction = getGeocoderFilterFunction(boundary, strict);
+        geocoder.setFilter(filterFunction);
+      }
+
       // Special case: actively loading a share config object
       // let configService.loadConfig apply the spatial filter
       if (loadingManager.has({ type: LoadingType.Share })) {
         return;
       }
-
-      const bbox = getBBox(boundary) as LngLatBoundsLike;
 
       map.fitBounds(bbox, { padding: 40 });
 

--- a/ui/src/services/map.service.ts
+++ b/ui/src/services/map.service.ts
@@ -15,15 +15,17 @@ import {
   Source,
 } from 'mapbox-gl';
 import { StoreApi, UseBoundStore } from 'zustand';
+import { getBBox } from '@/consts/bbox';
 import { getDefaultGeoJSON } from '@/consts/geojson';
-import { DEFAULT_BBOX, drawLayers } from '@/features/Map/consts';
+import { drawLayers } from '@/features/Map/consts';
 import { drawnFeatureContainsExtent } from '@/features/Map/utils';
 import { CollectionService } from '@/services/collection.service';
 import { ICollection } from '@/services/edr.service';
 import { FactoryService } from '@/services/factory.service';
 import { LocationService } from '@/services/location.service';
 import { PopupService } from '@/services/popup.service';
-import { Layer, MainState } from '@/stores/main/types';
+import { isSpatialSelectionPredefined } from '@/stores/main/slices/spatialSelection';
+import { Layer, MainState, PredefinedBoundary } from '@/stores/main/types';
 import { CollectionType, getCollectionType } from '@/utils/collection';
 import { isTopLayer } from '@/utils/isTopLayer';
 import {
@@ -99,6 +101,15 @@ export class MapService {
     return sourceId;
   }
 
+  private useCurrentBBox() {
+    const spatialSelection = this.store.getState().spatialSelection;
+    if (spatialSelection && isSpatialSelectionPredefined(spatialSelection)) {
+      return getBBox(spatialSelection.boundary);
+    }
+
+    return getBBox(PredefinedBoundary.Arizona);
+  }
+
   private addRasterSource(collection: ICollection, layerId: Layer['id']) {
     const link = collection.links.find(
       (link) => link.rel.includes('map') && link.type === 'image/png'
@@ -110,7 +121,7 @@ export class MapService {
       if (!source) {
         this.map.addSource(sourceId, {
           type: 'raster',
-          bounds: DEFAULT_BBOX,
+          bounds: this.useCurrentBBox(),
           tiles: [
             `${link.href}&bbox-crs=http://www.opengis.net/def/crs/EPSG/0/3857&bbox={bbox-epsg-3857}`,
           ],


### PR DESCRIPTION
### **Description**
The geocoder should now respect changes to the spatial boundaries, meaning results can including a wider area than Arizona when a user selects the Colorado River Basin option.

### **AC**
- [ ] Try searching for locations within the visual boundaries for both Arizona and Colorado River Basin
- [ ] Focusing on the Geocoder should close any other overlay elements
- [ ] Raster layers should now display to boundary if the data exists