### PR TITLE
Feature: allow drawn shapes in current boundary

### DIFF
--- a/ui/src/features/Panel/Layers/Layer/Color/Popover.tsx
+++ b/ui/src/features/Panel/Layers/Layer/Color/Popover.tsx
@@ -24,8 +24,6 @@ import {
   validColorBrewerIndex,
 } from '@/utils/colors/types';
 
-// C:\Users\jsalman\source\ArizonaWaterObservatory\ui\src\features\Panel\Layers\Layer\Color\Popover.tsx
-
 type Props = {
   paletteDefinition: Layer['paletteDefinition'];
   onChange: (paletteDefinition: Layer['paletteDefinition']) => void;

--- a/ui/src/features/Tools/SpatialSelection/Confirm.tsx
+++ b/ui/src/features/Tools/SpatialSelection/Confirm.tsx
@@ -3,17 +3,48 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { useMemo } from 'react';
+import { bbox, featureCollection } from '@turf/turf';
 import { Group, ModalProps, Stack, Text } from '@mantine/core';
 import Button from '@/components/Button';
 import Modal from '@/components/Modal';
 import { Variant } from '@/components/types';
+import { getBBox } from '@/consts/bbox';
+import { spatialService } from '@/services/init';
+import useMainStore from '@/stores/main';
+import { isSpatialSelectionPredefined } from '@/stores/main/slices/spatialSelection';
+import { PredefinedBoundary } from '@/stores/main/types';
 
 type Props = Pick<ModalProps, 'opened' | 'onClose'> & {
-  onConfirm: () => void;
+  onConfirm: (drawnShapesAreInvalid: boolean) => void;
 };
 
 export const Confirm: React.FC<Props> = (props) => {
   const { opened, onClose, onConfirm } = props;
+
+  const drawnShapes = useMainStore((state) => state.drawnShapes);
+  const spatialSelection = useMainStore((state) => state.spatialSelection);
+
+  const drawnShapesAreInvalid = useMemo(() => {
+    if (drawnShapes.length === 0) {
+      return false;
+    }
+
+    if (
+      spatialSelection &&
+      isSpatialSelectionPredefined(spatialSelection) &&
+      spatialSelection.boundary === PredefinedBoundary.ColoradoRiverBasin
+    ) {
+      const userBBox = bbox(featureCollection(drawnShapes));
+      const azBBox = getBBox(PredefinedBoundary.Arizona);
+
+      const { intersectsBoundary, smaller } = spatialService.validateBBox(userBBox, azBBox);
+
+      return !intersectsBoundary || !smaller;
+    }
+
+    return false;
+  }, [drawnShapes, spatialSelection]);
 
   // This modal needs to render above the popover (popover z index: 301)
   return (
@@ -32,8 +63,17 @@ export const Confirm: React.FC<Props> = (props) => {
         <Text ml="var(--default-spacing)">
           This action will require re-fetching data for all layers. This may take some time.
         </Text>
+        {drawnShapesAreInvalid && (
+          <Text ml="var(--default-spacing)">
+            There are drawn shapes outside of the new boundary. These will be removed.
+          </Text>
+        )}
         <Group gap="var(--default-spacing)">
-          <Button size="xs" variant={Variant.Primary} onClick={onConfirm}>
+          <Button
+            size="xs"
+            variant={Variant.Primary}
+            onClick={() => onConfirm(drawnShapesAreInvalid)}
+          >
             Ok
           </Button>
           <Button size="xs" variant={Variant.Tertiary} onClick={onClose}>

--- a/ui/src/features/Tools/SpatialSelection/index.tsx
+++ b/ui/src/features/Tools/SpatialSelection/index.tsx
@@ -4,6 +4,7 @@
  */
 
 import { ChangeEvent, useEffect, useState } from 'react';
+import { bbox } from '@turf/turf';
 import { Divider, Group, Radio, Stack, Text, Title, Tooltip } from '@mantine/core';
 import Info from '@/assets/Info';
 import SpatialSelectionIcon from '@/assets/SpatialSelection';
@@ -11,12 +12,14 @@ import Checkbox from '@/components/Checkbox';
 import IconButton from '@/components/IconButton';
 import Popover from '@/components/Popover';
 import { Variant } from '@/components/types';
+import { getBBox } from '@/consts/bbox';
 import { useMap } from '@/contexts/MapContexts';
 import { MAP_ID } from '@/features/Map/config';
 import { Confirm } from '@/features/Tools/SpatialSelection/Confirm';
 import styles from '@/features/Tools/Tools.module.css';
 import { useConfirmableAction } from '@/hooks/useConfirmableAction';
 import { useLoading } from '@/hooks/useLoading';
+import { spatialService } from '@/services/init';
 import useMainStore from '@/stores/main';
 import {
   isPredefinedBoundary,
@@ -36,6 +39,7 @@ const SpatialSelection: React.FC = () => {
   const setSpatialSelectionPredefinedBoundary = useMainStore(
     (state) => state.setSpatialSelectionPredefinedBoundary
   );
+  const drawnShapes = useMainStore((state) => state.drawnShapes);
   const setDrawnShapes = useMainStore((state) => state.setDrawnShapes);
   const setSpatialSelectionStrict = useMainStore((state) => state.setSpatialSelectionStrict);
 
@@ -102,12 +106,25 @@ const SpatialSelection: React.FC = () => {
 
   const handleConfirm = (drawnShapesAreInvalid: boolean) => {
     if (drawnShapesAreInvalid) {
+      const azBBox = getBBox(PredefinedBoundary.Arizona);
+      // Find all shapes that are within the new boundary
+      const validShapes = drawnShapes.filter((shape) => {
+        const shapeBBox = bbox(shape);
+        const { intersectsBoundary, smaller } = spatialService.validateBBox(shapeBBox, azBBox);
+
+        return intersectsBoundary && smaller;
+      });
+
       // Clear shapes
-      setDrawnShapes([]);
+      setDrawnShapes(validShapes);
 
       if (draw) {
-        draw.trash();
-        draw.deleteAll();
+        // Find all shapes that are no longer valid and remove them from the draw instance
+        const invalidShapeIds = drawnShapes
+          .filter((shape) => !validShapes.some((validShape) => validShape.id === shape.id))
+          .map((shape) => String(shape.id));
+
+        draw.delete(invalidShapeIds);
       }
     }
     confirmAction.confirm();

--- a/ui/src/features/Tools/SpatialSelection/index.tsx
+++ b/ui/src/features/Tools/SpatialSelection/index.tsx
@@ -11,6 +11,8 @@ import Checkbox from '@/components/Checkbox';
 import IconButton from '@/components/IconButton';
 import Popover from '@/components/Popover';
 import { Variant } from '@/components/types';
+import { useMap } from '@/contexts/MapContexts';
+import { MAP_ID } from '@/features/Map/config';
 import { Confirm } from '@/features/Tools/SpatialSelection/Confirm';
 import styles from '@/features/Tools/Tools.module.css';
 import { useConfirmableAction } from '@/hooks/useConfirmableAction';
@@ -34,11 +36,14 @@ const SpatialSelection: React.FC = () => {
   const setSpatialSelectionPredefinedBoundary = useMainStore(
     (state) => state.setSpatialSelectionPredefinedBoundary
   );
+  const setDrawnShapes = useMainStore((state) => state.setDrawnShapes);
   const setSpatialSelectionStrict = useMainStore((state) => state.setSpatialSelectionStrict);
 
   const confirmAction = useConfirmableAction(hasLayers);
 
   const { isLoadingGeography } = useLoading();
+
+  const { draw } = useMap(MAP_ID);
 
   const [show, setShow] = useState(false);
 
@@ -95,12 +100,25 @@ const SpatialSelection: React.FC = () => {
     }
   };
 
+  const handleConfirm = (drawnShapesAreInvalid: boolean) => {
+    if (drawnShapesAreInvalid) {
+      // Clear shapes
+      setDrawnShapes([]);
+
+      if (draw) {
+        draw.trash();
+        draw.deleteAll();
+      }
+    }
+    confirmAction.confirm();
+  };
+
   return (
     <>
       <Confirm
         opened={confirmAction.opened}
         onClose={confirmAction.close}
-        onConfirm={confirmAction.confirm}
+        onConfirm={handleConfirm}
       />
       <Popover
         offset={16}

--- a/ui/src/hooks/useSpatialSelection.ts
+++ b/ui/src/hooks/useSpatialSelection.ts
@@ -39,6 +39,7 @@ export const ARIZONA_ID_NUMERIC = Number(ARIZONA_ID);
 export const useSpatialSelection = (map: Map | null, geocoder: MapboxGeocoder | null) => {
   const spatialSelection = useMainStore((state) => state.spatialSelection);
   const layerCount = useMainStore((state) => state.layers.length);
+  const drawnShapes = useMainStore((state) => state.drawnShapes);
 
   const fetchLowerColoradoBasin = (signal: AbortSignal) => {
     return geoconnexService.getItem<Feature<Polygon | MultiPolygon>>('hu02', LOWER_COLORADO_ID, {
@@ -208,7 +209,7 @@ export const useSpatialSelection = (map: Map | null, geocoder: MapboxGeocoder | 
 
       // Reapply spatial filters for all layers to include new bounds
       mainManager
-        .applySpatialFilter([], { rethrow: true, signal: controller.signal })
+        .applySpatialFilter(drawnShapes, { signal: controller.signal })
         .catch((error) => {
           if ((error as Error)?.message) {
             const _error = error as Error;

--- a/ui/src/managers/main/Main.manager.ts
+++ b/ui/src/managers/main/Main.manager.ts
@@ -389,12 +389,15 @@ class MainManager {
 
       for (const result of settled) {
         if (result.status === 'rejected') {
-          this.deps.notificationManager.show(
-            'An error occurred while applying a spatial filter, check the console for more details.',
-            NotificationVariant.Error,
-            10000
-          );
-          console.error('applySpatialFilter: addData failed:', result.reason);
+          if (typeof result.reason === 'string') {
+            this.deps.notificationManager.show(result.reason, NotificationVariant.Error, 10000);
+          } else if ('message' in result.reason && typeof result.reason.message === 'string') {
+            this.deps.notificationManager.show(
+              result.reason.message,
+              NotificationVariant.Error,
+              10000
+            );
+          }
         }
       }
     }

--- a/ui/src/managers/types.ts
+++ b/ui/src/managers/types.ts
@@ -72,6 +72,5 @@ export type ExtendedFeatureCollection<
 };
 
 export type ApplySpatialFilterOptions = {
-  rethrow: boolean;
   signal?: AbortSignal;
 };

--- a/ui/src/services/spatial.service.ts
+++ b/ui/src/services/spatial.service.ts
@@ -30,10 +30,12 @@ export class SpatialService {
     this.store = store;
   }
 
-  private checkCollectionBBoxRestrictions(collectionId: ICollection['id'], area: number) {
+  private checkCollectionBBoxRestrictions(collectionId: ICollection['id'], bbox: BBox) {
     const restrictions = CollectionRestrictions[collectionId];
 
     if (restrictions && restrictions.length > 0) {
+      const area = turf.area(turf.bboxPolygon(bbox));
+
       const sizeRestriction = restrictions.find(
         (restriction) => restriction.type === RestrictionType.Size
       );
@@ -48,7 +50,25 @@ export class SpatialService {
     }
   }
 
-  private validateBBox(bbox: BBox, collectionId: ICollection['id']) {
+  public validateBBox(userBBox: BBox, boundaryBBox: BBox) {
+    const userBBoxPolygon = turf.bboxPolygon(userBBox);
+    const boundaryBBoxPolygon = turf.bboxPolygon(boundaryBBox);
+
+    const userBBoxArea = turf.area(userBBoxPolygon);
+    const boundaryBBoxArea = turf.area(boundaryBBoxPolygon);
+
+    const intersectsBoundary = turf.booleanIntersects(userBBoxPolygon, boundaryBBoxPolygon);
+    const containsBoundary = turf.booleanContains(userBBoxPolygon, boundaryBBoxPolygon);
+    const smaller = userBBoxArea <= boundaryBBoxArea;
+
+    return {
+      intersectsBoundary,
+      containsBoundary,
+      smaller,
+    };
+  }
+
+  private validateDataBoundary(bbox: BBox, collectionId: ICollection['id']) {
     const spatialSelection = this.store.getState().spatialSelection;
 
     const boundaryBBox =
@@ -56,20 +76,12 @@ export class SpatialService {
         ? getBBox(spatialSelection.boundary)
         : DEFAULT_BBOX;
 
-    const userBBox = turf.bboxPolygon(bbox);
-    const boundaryBBoxPolygon = turf.bboxPolygon(boundaryBBox);
-
-    const userBBoxArea = turf.area(userBBox);
-    const boundaryBBoxArea = turf.area(boundaryBBoxPolygon);
+    const { intersectsBoundary, containsBoundary, smaller } = this.validateBBox(bbox, boundaryBBox);
 
     // Valid bbox should touch the AZ bbox, not contain it fully, and be smaller than the size limit
     // Certain collections have additional size restrictions due to large datasets
     // Throw errors to stop process and provide feedback to user
-    this.checkCollectionBBoxRestrictions(collectionId, userBBoxArea);
-
-    const intersectsBoundary = turf.booleanIntersects(userBBox, boundaryBBoxPolygon);
-    const containsBoundary = turf.booleanContains(userBBox, boundaryBBoxPolygon);
-    const smaller = userBBoxArea <= boundaryBBoxArea;
+    this.checkCollectionBBoxRestrictions(collectionId, bbox);
 
     if (!intersectsBoundary) {
       throw new Error('Target area not connected to Data Boundary.');
@@ -88,11 +100,9 @@ export class SpatialService {
 
     if (drawnShapes.length === 0) {
       if (canThrowErrors) {
-        this.checkCollectionBBoxRestrictions(
-          collectionId,
-          turf.area(turf.bboxPolygon(DEFAULT_BBOX))
-        );
+        this.checkCollectionBBoxRestrictions(collectionId, DEFAULT_BBOX);
       }
+
       const spatialSelection = this.store.getState().spatialSelection;
       if (spatialSelection && isSpatialSelectionPredefined(spatialSelection)) {
         return getBBox(spatialSelection.boundary);
@@ -106,7 +116,7 @@ export class SpatialService {
     const userBBox = turf.bbox(featureCollection);
 
     if (canThrowErrors) {
-      this.validateBBox(userBBox, collectionId);
+      this.validateDataBoundary(userBBox, collectionId);
     }
 
     return userBBox;

--- a/ui/src/services/spatial.service.ts
+++ b/ui/src/services/spatial.service.ts
@@ -49,29 +49,36 @@ export class SpatialService {
   }
 
   private validateBBox(bbox: BBox, collectionId: ICollection['id']) {
+    const spatialSelection = this.store.getState().spatialSelection;
+
+    const boundaryBBox =
+      spatialSelection && isSpatialSelectionPredefined(spatialSelection)
+        ? getBBox(spatialSelection.boundary)
+        : DEFAULT_BBOX;
+
     const userBBox = turf.bboxPolygon(bbox);
-    const AZBBox = turf.bboxPolygon(DEFAULT_BBOX);
+    const boundaryBBoxPolygon = turf.bboxPolygon(boundaryBBox);
 
     const userBBoxArea = turf.area(userBBox);
-    const AZBBoxArea = turf.area(AZBBox);
+    const boundaryBBoxArea = turf.area(boundaryBBoxPolygon);
 
     // Valid bbox should touch the AZ bbox, not contain it fully, and be smaller than the size limit
     // Certain collections have additional size restrictions due to large datasets
     // Throw errors to stop process and provide feedback to user
     this.checkCollectionBBoxRestrictions(collectionId, userBBoxArea);
 
-    const intersectsAZ = turf.booleanIntersects(userBBox, AZBBox);
-    const containsAZ = turf.booleanContains(userBBox, AZBBox);
-    const smaller = userBBoxArea <= AZBBoxArea;
+    const intersectsBoundary = turf.booleanIntersects(userBBox, boundaryBBoxPolygon);
+    const containsBoundary = turf.booleanContains(userBBox, boundaryBBoxPolygon);
+    const smaller = userBBoxArea <= boundaryBBoxArea;
 
-    if (!intersectsAZ) {
-      throw new Error('Target area not connected to Arizona.');
+    if (!intersectsBoundary) {
+      throw new Error('Target area not connected to Data Boundary.');
     }
-    if (containsAZ) {
-      throw new Error('Target area can not contain Arizona.');
+    if (containsBoundary) {
+      throw new Error('Target area can not contain Data Boundary.');
     }
     if (!smaller) {
-      throw new Error('Target area must be smaller than Arizona.');
+      throw new Error('Target area must be smaller than Data Boundary.');
     }
   }
 


### PR DESCRIPTION
### **Description**
Attempts to draw shapes outside of Arizona would be blocked even when the data boundary was set to the Colorado River Basin. This update allows that as well as adds handling for when users are transitioning from the Colorado River Basin back to Arizona with a drawn shape.

### **AC**
- [x] Drawing a shape outside of the data boundary is not allowed
- [x] Drawing a shape within any data boundary is allowed
- [x] If a drawn shape will be outside of the data boundary after change:
    - [x] Extra message appears in confirmation modal: "There are drawn shapes outside of the new boundary. These will be removed."
    - [x] Drawn shapes not within the new boundary will be removed after confirmation, those within stay