### PR TITLE
Fix: Only use locations from the correct layer

### DIFF
--- a/ui/src/features/Compare/Panel/index.tsx
+++ b/ui/src/features/Compare/Panel/index.tsx
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { useMemo } from 'react';
 import { Box } from '@mantine/core';
 import Accordion from '@/components/Accordion';
 import Collapsible from '@/components/Collapsible';
@@ -52,6 +53,19 @@ const Panel: React.FC<Props> = (props) => {
     onOpen();
   };
 
+  const locationsByLayer = useMemo(() => {
+    const map = new Map<string, Location[]>();
+
+    for (const loc of locations) {
+      if (!map.has(loc.layerId)) {
+        map.set(loc.layerId, []);
+      }
+      map.get(loc.layerId)!.push(loc);
+    }
+
+    return map;
+  }, [locations]);
+
   return (
     <Collapsible
       width="25rem"
@@ -76,7 +90,7 @@ const Panel: React.FC<Props> = (props) => {
                       content: (
                         <Layer
                           layer={layer}
-                          locations={locations}
+                          locations={locationsByLayer.get(layer.id) ?? []}
                           onLocationAdd={onLocationAdd}
                           onLocationRemove={onLocationRemove}
                         />


### PR DESCRIPTION
### **Description**
Addresses a bug when the same location from the same dataset would appear to be falsely selected across two layers.

### **Current Behavior:**
With 2 layers of the same dataset, any location selected on one in the compare tool is automatically selected in the other

### **Expected Behavior:**
These locations are treated as separate and can be selected independently.