### PR TITLE
Remove animations, wait for idle

### DIFF
--- a/ui/src/features/Tools/Screenshot.tsx
+++ b/ui/src/features/Tools/Screenshot.tsx
@@ -48,6 +48,7 @@ export const Screenshot: React.FC = () => {
 
   const isMovingRef = useRef(false);
   const isMounted = useRef(true);
+
   const updateSource = (src: string) => {
     if (isMounted.current) {
       setSrc(src);
@@ -72,12 +73,14 @@ export const Screenshot: React.FC = () => {
 
     cloneMap.resize();
     cloneMap.setStyle(originalMap.getStyle());
-    cloneMap.setCenter(originalMap.getCenter());
-    cloneMap.setZoom(originalMap.getZoom());
-    cloneMap.setBearing(originalMap.getBearing());
-    cloneMap.setPitch(originalMap.getPitch());
+    cloneMap.setCenter(originalMap.getCenter(), { animate: false });
+    cloneMap.setZoom(originalMap.getZoom(), { animate: false });
+    cloneMap.setBearing(originalMap.getBearing(), { animate: false });
+    cloneMap.setPitch(originalMap.getPitch(), { animate: false });
 
-    handleCreateMapImage(cloneMap, width, height, false, updateSource, updateLoading);
+    cloneMap.once('idle', () => {
+      handleCreateMapImage(cloneMap, width, height, false, updateSource, updateLoading);
+    });
   };
 
   useEffect(() => {
@@ -140,6 +143,7 @@ export const Screenshot: React.FC = () => {
     }
 
     if (show) {
+      console.log('refresh');
       void handleScreenshot(map, cloneMap.current, container.current, width, height);
     }
 

--- a/ui/src/features/Tools/Screenshot.tsx
+++ b/ui/src/features/Tools/Screenshot.tsx
@@ -143,7 +143,6 @@ export const Screenshot: React.FC = () => {
     }
 
     if (show) {
-      console.log('refresh');
       void handleScreenshot(map, cloneMap.current, container.current, width, height);
     }
 


### PR DESCRIPTION
### **Description**
Resolve issues with partial rendered screenshots.

### **Current Behavior**
Make a large move or change in the map (ie change the data boundary AZ -> CO River Basin). Map shows in a partial rendered state in the screenshot tool

### **Expected Behavior**
Screenshot tool does not show image until fully rendered.