### PR TITLE
feat(ui): Improved layout positions

### DIFF
--- a/ui/src/features/Loading/Info.tsx
+++ b/ui/src/features/Loading/Info.tsx
@@ -14,7 +14,6 @@ import {
   Text,
   Title,
 } from '@mantine/core';
-import styles from '@/features/Loading/Loading.module.css';
 
 type Props = {
   loadingTexts: string[];
@@ -26,9 +25,7 @@ export const Info: React.FC<PropsWithChildren<Props>> = (props) => {
   return (
     <HoverCard width={300} shadow="md" position="top" withArrow>
       <HoverCardTarget>
-        <Box w="100%" className={styles.loadingBar}>
-          {children}
-        </Box>
+        <Box w="100%">{children}</Box>
       </HoverCardTarget>
       <HoverCardDropdown>
         <Title order={4}>Loading:</Title>

--- a/ui/src/features/Loading/Loading.module.css
+++ b/ui/src/features/Loading/Loading.module.css
@@ -3,10 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-.loadingBar {
-  z-index: 9999;
-}
-
 .mobile {
   display: none;
 }

--- a/ui/src/features/Tools/Mobile.tsx
+++ b/ui/src/features/Tools/Mobile.tsx
@@ -21,7 +21,7 @@ export const Mobile: React.FC = () => {
 
   return (
     <Box className={styles.mobileWrapper}>
-      <Group gap="calc(var(--default-spacing) * 2)">
+      <Group gap="calc(var(--default-spacing) * 2)" className={styles.mobileToolWrapper}>
         <Info />
         <IconButton variant={opened ? Variant.Selected : Variant.Secondary} onClick={toggle}>
           <Tools />

--- a/ui/src/features/Tools/Tools.module.css
+++ b/ui/src/features/Tools/Tools.module.css
@@ -142,8 +142,12 @@
   position: absolute;
   right: var(--default-spacing);
   top: var(--default-spacing);
-  width: 84px;
   display: none;
+}
+
+.mobileToolWrapper {
+  width: fit-content;
+  margin-left: auto;
 }
 
 .row {
@@ -159,10 +163,6 @@
 @media screen and (max-width: 899px) {
   .mobileWrapper {
     display: block;
-  }
-
-  .geocoderWrapper {
-    min-width: calc(100vw - (var(--default-spacing) * 2));
   }
 
   .dateSelectorButton {

--- a/ui/src/pages/Layout.page.tsx
+++ b/ui/src/pages/Layout.page.tsx
@@ -103,11 +103,11 @@ export const LayoutPage: React.FC = () => {
 
   return (
     <Box className={styles.root}>
-      <Stack gap={0} className={styles.fullHeight}>
-        <Group gap={0} align="flex-start" className={styles.fullHeight}>
-          <Panel />
-          <Stack gap={0} className={styles.right}>
-            <TopBar />
+      <Group gap={0} align="flex-start" className={styles.fullHeight}>
+        <Panel />
+        <Stack gap={0} className={styles.right}>
+          <TopBar />
+          <Box className={styles.mapWrapper}>
             <Outlet />
             <Box className={styles.cgsLogo}>
               <Anchor target="_blank" href="https://cgsearth.org/">
@@ -122,10 +122,10 @@ export const LayoutPage: React.FC = () => {
                 />
               </Anchor>
             </Box>
-            <Loading />
-          </Stack>
-        </Group>
-      </Stack>
+          </Box>
+          <Loading />
+        </Stack>
+      </Group>
       <Notifications />
       {mobile && <MobileTools />}
     </Box>

--- a/ui/src/pages/pages.module.css
+++ b/ui/src/pages/pages.module.css
@@ -3,11 +3,20 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-.root {
-  height: 100vh;
-  max-width: 100vw;
-  max-height: 100vh;
-  overflow: hidden;
+.cgsLogo {
+  position: absolute;
+  bottom: calc(var(--default-spacing) / 4);
+  left: 104px;
+}
+
+.fullHeight {
+  height: 100%;
+}
+
+.mapWrapper {
+  position: relative;
+  width: auto;
+  height: 100%;
 }
 
 .right {
@@ -16,12 +25,9 @@
   height: 100%;
 }
 
-.fullHeight {
-  height: 100%;
-}
-
-.cgsLogo {
-  position: absolute;
-  bottom: var(--default-spacing);
-  left: 104px;
+.root {
+  height: 100vh;
+  max-width: 100vw;
+  max-height: 100vh;
+  overflow: hidden;
 }


### PR DESCRIPTION
### **Description**
Adjusts the positioning of the logo so that it is never covered by the loading bar. Also fixes a bug with the position of the mobile tools tray.

### **To Test:**

- Add datasets, add a coverage layer (PRISM) with a visual expression. Test for unexpected layout behaviors
- Switch to a mobile view, check that tools are accessible (top right) and never obscure other elements