### PR TITLE
fix(ui): associate datasets to providers

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -2,7 +2,7 @@
   "name": "awo-ui",
   "private": true,
   "type": "module",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "scripts": {
     "dev": "vite --host",
     "build": "tsc && vite build",

--- a/ui/src/consts/collections.ts
+++ b/ui/src/consts/collections.ts
@@ -7,9 +7,11 @@ import { CollectionType } from '@/utils/collection';
 
 export enum CollectionId {
   RISEEdr = 'rise-edr',
+
   SNOTELEdr = 'snotel-edr',
+  AWDB = 'awdb-forecasts-edr',
+
   USACEEdr = 'usace-edr',
-  Streamgages = 'usgs-sta',
 
   NWMChannelRouting = 'National_Water_Model_Channel_Routing_Output',
   NWMAssimilationSystem = 'National_Water_Model_Land_Data_Assimilation_System_Output',
@@ -18,29 +20,74 @@ export enum CollectionId {
   NWMGroundwaterOutput = 'National_Water_Model_Groundwater_Output',
 
   ArizonaWaterWells = 'ArizonaWaterWells',
-  AWDB = 'awdb-forecasts-edr',
+  ActiveManagementAreas = 'Active_Management_Areas_2025',
+  GroundwaterBasins = 'Arizona_Groundwater_Basins',
+  IrrigationDistricts = 'ArizonaIrrigationDistricts',
 
   NOAARFC = 'noaa-rfc',
+  NOAARiverStageForecastDay1 = 'noaa-river-stage-forecast-day-1',
+  NOAARiverStageForecastDay2 = 'noaa-river-stage-forecast-day-2',
+  NOAARiverStageForecastDay3 = 'noaa-river-stage-forecast-day-3',
+  NOAARiverStageForecastDay10 = 'noaa-river-stage-forecast-day-10',
+
   PRISM = 'usgs-prism',
+  NationalMapElevation = 'usgs-national-map_elevation',
+  NationalMapLandCover = 'usgs-national-map_land-cover',
+  Streamgages = 'usgs-sta',
+  Aquifers = 'Aquifers_USGS_West',
+
+  CentralArizonaProjectCanal = 'CentralArizonaProjectCanal',
+
+  GRACEGroundwaterStorage = 'ASU_LCRB_GRACE',
+  GRACEGroundwaterBasins = 'ASU_Groundwater_Basins_Aggregated_Grace',
   GRACE = 'GRACE',
+  SMAP = 'SMAP_SPL4SMGP',
 }
 
 export enum Provider {
+  ADWR = 'adwr',
+  ASU = 'asu',
+  CAP = 'cap',
+  NASA = 'nasa',
+  NOAA = 'noaa',
+  USACE = 'usace',
   USBR = 'usbr',
   USDA = 'usda',
   USGS = 'usgs',
-  USACE = 'usace',
-  NOAA = 'noaa',
-  NASA = 'nasa',
 }
 
 export const ProviderDatasources: Record<Provider, string[]> = {
-  [Provider.USBR]: [],
-  [Provider.USDA]: [],
-  [Provider.USGS]: [],
-  [Provider.USACE]: [],
-  [Provider.NOAA]: [],
-  [Provider.NASA]: [],
+  [Provider.ASU]: [CollectionId.GRACEGroundwaterBasins, CollectionId.GRACEGroundwaterStorage],
+  [Provider.USBR]: [CollectionId.RISEEdr],
+  [Provider.USDA]: [CollectionId.SNOTELEdr, CollectionId.AWDB],
+  [Provider.USGS]: [
+    CollectionId.PRISM,
+    CollectionId.NationalMapElevation,
+    CollectionId.NationalMapLandCover,
+    CollectionId.Streamgages,
+    CollectionId.Aquifers,
+  ],
+  [Provider.USACE]: [CollectionId.USACEEdr],
+  [Provider.NOAA]: [
+    CollectionId.NWMChannelRouting,
+    CollectionId.NWMAssimilationSystem,
+    CollectionId.NWMReachToReach,
+    CollectionId.NWMLakeOutput,
+    CollectionId.NWMGroundwaterOutput,
+    CollectionId.NOAARFC,
+    CollectionId.NOAARiverStageForecastDay1,
+    CollectionId.NOAARiverStageForecastDay2,
+    CollectionId.NOAARiverStageForecastDay3,
+    CollectionId.NOAARiverStageForecastDay10,
+  ],
+  [Provider.NASA]: [CollectionId.SMAP],
+  [Provider.ADWR]: [
+    CollectionId.ArizonaWaterWells,
+    CollectionId.ActiveManagementAreas,
+    CollectionId.GroundwaterBasins,
+    CollectionId.IrrigationDistricts,
+  ],
+  [Provider.CAP]: [CollectionId.CentralArizonaProjectCanal],
 };
 
 export const idStoreProperty = 'id_store';

--- a/ui/src/consts/collections.ts
+++ b/ui/src/consts/collections.ts
@@ -33,7 +33,6 @@ export enum CollectionId {
   PRISM = 'usgs-prism',
   NationalMapElevation = 'usgs-national-map_elevation',
   NationalMapLandCover = 'usgs-national-map_land-cover',
-  Streamgages = 'usgs-sta',
   Aquifers = 'Aquifers_USGS_West',
 
   CentralArizonaProjectCanal = 'CentralArizonaProjectCanal',
@@ -64,7 +63,6 @@ export const ProviderDatasources: Record<Provider, string[]> = {
     CollectionId.PRISM,
     CollectionId.NationalMapElevation,
     CollectionId.NationalMapLandCover,
-    CollectionId.Streamgages,
     CollectionId.Aquifers,
   ],
   [Provider.USACE]: [CollectionId.USACEEdr],
@@ -97,7 +95,6 @@ export const StringIdentifierCollections: string[] = [
   CollectionId.AWDB,
   CollectionId.ArizonaWaterWells,
   CollectionId.NWMLakeOutput,
-  CollectionId.Streamgages,
   CollectionId.SNOTELEdr,
   CollectionId.NOAARFC,
 ];

--- a/ui/src/features/Panel/Datasets/Dataset/Header.tsx
+++ b/ui/src/features/Panel/Datasets/Dataset/Header.tsx
@@ -7,7 +7,6 @@ import { Stack, Text, Tooltip } from '@mantine/core';
 import styles from '@/features/Panel/Panel.module.css';
 import { ICollection } from '@/services/edr.service';
 import { getParameterList } from '@/utils/parameters';
-import { getProvider } from '@/utils/provider';
 
 type Props = {
   dataset: ICollection;
@@ -16,15 +15,13 @@ type Props = {
 export const Header: React.FC<Props> = (props) => {
   const { dataset } = props;
 
-  const provider = getProvider(dataset.id);
-
   const parameters = getParameterList(dataset);
 
   return (
     <Tooltip label="Click to show dataset details" openDelay={500}>
       <Stack justify="center" gap="calc(var(--default-spacing) / 4)">
         <Text component="h3" size="lg" lineClamp={2} title={dataset.title} fw={500}>
-          <strong>{provider}</strong> {dataset.title}
+          {dataset.title}
         </Text>
         {parameters.length > 0 && (
           <Text size="xs" lineClamp={2} className={styles.datasetsParameterList}>

--- a/ui/src/features/Panel/Datasets/Filter/Modal/Provider.tsx
+++ b/ui/src/features/Panel/Datasets/Filter/Modal/Provider.tsx
@@ -45,7 +45,7 @@ export const Provider: React.FC<Props> = (props) => {
           </>
         }
         placeholder="Select..."
-        data={['USACE', 'USDA', 'NOAA', 'USBR', 'USGS']}
+        data={['ASU', 'ADWR', 'CAP', 'NASA', 'NOAA', 'USACE', 'USBR', 'USDA', 'USGS']}
         value={provider}
         onChange={onChange}
         searchable

--- a/ui/src/features/Panel/Layers/Layer/Header.tsx
+++ b/ui/src/features/Panel/Layers/Layer/Header.tsx
@@ -11,7 +11,6 @@ import { ICollection } from '@/services/edr.service';
 import { collectionService } from '@/services/init';
 import { Layer } from '@/stores/main/types';
 import { CollectionType, getCollectionType } from '@/utils/collection';
-import { getProvider } from '@/utils/provider';
 
 type Props = {
   layer: Layer;
@@ -24,7 +23,7 @@ export const Header: React.FC<Props> = (props) => {
 
   const [dataset, setDataset] = useState<ICollection>();
   const [parameters, setParameters] = useState<string[]>([]);
-  const [provider, setProvider] = useState<string>('');
+  // const [provider, setProvider] = useState<string>('');
   const [collectionType, setCollectionType] = useState<CollectionType>(CollectionType.Unknown);
 
   const { isFetchingCollections } = useLoading();
@@ -51,20 +50,11 @@ export const Header: React.FC<Props> = (props) => {
     }
   }, [layer, isFetchingCollections]);
 
-  useEffect(() => {
-    if (!dataset || provider.length > 0) {
-      return;
-    }
-
-    const newProvider = getProvider(dataset.id);
-    setProvider(newProvider);
-  }, [dataset, isFetchingCollections]);
-
   return (
     <Stack justify="center" gap="calc(var(--default-spacing) / 4)">
       {dataset && (
         <Text component="h3" size="md" lineClamp={1} title={dataset.title}>
-          <strong>{provider}</strong> {dataset.title}
+          {dataset.title}
         </Text>
       )}
 

--- a/ui/src/features/Panel/Layers/Layer/Header.tsx
+++ b/ui/src/features/Panel/Layers/Layer/Header.tsx
@@ -23,7 +23,6 @@ export const Header: React.FC<Props> = (props) => {
 
   const [dataset, setDataset] = useState<ICollection>();
   const [parameters, setParameters] = useState<string[]>([]);
-  // const [provider, setProvider] = useState<string>('');
   const [collectionType, setCollectionType] = useState<CollectionType>(CollectionType.Unknown);
 
   const { isFetchingCollections } = useLoading();

--- a/ui/src/utils/provider.ts
+++ b/ui/src/utils/provider.ts
@@ -7,6 +7,21 @@ import { Provider, ProviderDatasources } from '@/consts/collections';
 import { ICollection } from '@/services/edr.service';
 
 export const getProvider = (collectionId: ICollection['id']): string => {
+  if (ProviderDatasources[Provider.ADWR].includes(collectionId)) {
+    return Provider.ADWR.toUpperCase();
+  }
+  if (ProviderDatasources[Provider.ASU].includes(collectionId)) {
+    return Provider.ASU.toUpperCase();
+  }
+  if (ProviderDatasources[Provider.NASA].includes(collectionId)) {
+    return Provider.NASA.toUpperCase();
+  }
+  if (ProviderDatasources[Provider.CAP].includes(collectionId)) {
+    return Provider.CAP.toUpperCase();
+  }
+  if (ProviderDatasources[Provider.NOAA].includes(collectionId)) {
+    return Provider.NOAA.toUpperCase();
+  }
   if (ProviderDatasources[Provider.USBR].includes(collectionId)) {
     return Provider.USBR.toUpperCase();
   }


### PR DESCRIPTION
This fix allows the Provider filter to apply as expected by manually assigning the provider relationship to datasets.